### PR TITLE
Feature: Keep selected row displayed

### DIFF
--- a/EventLook/View/MainWindow.xaml
+++ b/EventLook/View/MainWindow.xaml
@@ -113,7 +113,7 @@
             </Expander>
 
             <!-- *** The ItemsSource of the data grid is bound to the CollectionViewSource object that was instantiated above -->
-            <DataGrid ItemsSource="{Binding Source={StaticResource X_CVS}}" SelectedItem="{Binding SelectedEventItem}" 
+            <DataGrid ItemsSource="{Binding Source={StaticResource X_CVS}}" SelectedItem="{Binding SelectedEventItem}" SelectedCellsChanged="DataGrid_SelectedCellsChanged"
                       Margin="5" Grid.Row="2" AutoGenerateColumns="False" IsReadOnly="True"
                   BorderBrush="LightSteelBlue" HorizontalGridLinesBrush="LightSteelBlue" VerticalGridLinesBrush="LightSteelBlue" AllowDrop="True" PreviewDragOver="OnPreviewDragOver" Drop="OnDrop">
                 <DataGrid.Resources>

--- a/EventLook/View/MainWindow.xaml
+++ b/EventLook/View/MainWindow.xaml
@@ -113,7 +113,7 @@
             </Expander>
 
             <!-- *** The ItemsSource of the data grid is bound to the CollectionViewSource object that was instantiated above -->
-            <DataGrid ItemsSource="{Binding Source={StaticResource X_CVS}}" SelectedItem="{Binding SelectedEvent}" 
+            <DataGrid ItemsSource="{Binding Source={StaticResource X_CVS}}" SelectedItem="{Binding SelectedEventItem}" 
                       Margin="5" Grid.Row="2" AutoGenerateColumns="False" IsReadOnly="True"
                   BorderBrush="LightSteelBlue" HorizontalGridLinesBrush="LightSteelBlue" VerticalGridLinesBrush="LightSteelBlue" AllowDrop="True" PreviewDragOver="OnPreviewDragOver" Drop="OnDrop">
                 <DataGrid.Resources>

--- a/EventLook/View/MainWindow.xaml
+++ b/EventLook/View/MainWindow.xaml
@@ -117,9 +117,17 @@
                       Margin="5" Grid.Row="2" AutoGenerateColumns="False" IsReadOnly="True"
                   BorderBrush="LightSteelBlue" HorizontalGridLinesBrush="LightSteelBlue" VerticalGridLinesBrush="LightSteelBlue" AllowDrop="True" PreviewDragOver="OnPreviewDragOver" Drop="OnDrop">
                 <DataGrid.Resources>
-                    <SolidColorBrush x:Key="{x:Static SystemColors.HighlightBrushKey}" Color="LightGray"/>
+                    <SolidColorBrush x:Key="{x:Static SystemColors.HighlightBrushKey}" Color="LightSkyBlue"/>
                     <SolidColorBrush x:Key="{x:Static SystemColors.HighlightTextBrushKey }" Color="Black"/>
+                    <SolidColorBrush x:Key="{x:Static SystemColors.InactiveSelectionHighlightBrushKey}" Color="LightSteelBlue"/>
+                    <SolidColorBrush x:Key="{x:Static SystemColors.InactiveSelectionHighlightTextBrushKey }" Color="Black"/>
                 </DataGrid.Resources>
+                <DataGrid.CellStyle>
+                    <Style TargetType="DataGridCell">
+                        <Setter Property="BorderThickness" Value="0"/>
+                        <Setter Property="FocusVisualStyle" Value="{x:Null}"/>
+                    </Style>
+                </DataGrid.CellStyle>
                 <DataGrid.InputBindings>
                     <MouseBinding Gesture="LeftDoubleClick" Command="{Binding OpenDetailsCommand}" />
                     <KeyBinding Key="Enter" Command="{Binding OpenDetailsCommand}" />

--- a/EventLook/View/MainWindow.xaml.cs
+++ b/EventLook/View/MainWindow.xaml.cs
@@ -75,5 +75,11 @@ namespace EventLook
                 }
             }
         }
+
+        private void DataGrid_SelectedCellsChanged(object sender, SelectedCellsChangedEventArgs e)
+        {
+            if (sender is DataGrid dataGrid && dataGrid.SelectedItem != null)
+                dataGrid.ScrollIntoView(dataGrid.SelectedItem);
+        }
     }
 }

--- a/EventLook/ViewModel/MainViewModel.cs
+++ b/EventLook/ViewModel/MainViewModel.cs
@@ -78,7 +78,7 @@ namespace EventLook.ViewModel
                 RaisePropertyChanged();
             }
         }
-        public EventItem SelectedEvent { get; set; }
+        public EventItem SelectedEventItem { get; set; }
 
         public ObservableCollection<LogSource> LogSources
         {
@@ -233,7 +233,7 @@ namespace EventLook.ViewModel
         }
         private void OpenDetails()
         {
-            var detailVm = new DetailViewModel(SelectedEvent);
+            var detailVm = new DetailViewModel(SelectedEventItem);
             showWindowService.Show(detailVm);
         }
 


### PR DESCRIPTION
With this update, the app tries to keep selected row displayed when the DataGrid items are sorted or filtered. It was one of UX improvement candidates in #6.