### PR TITLE
Launch Windows Event Viewer

### DIFF
--- a/EventLook/View/MainWindow.xaml
+++ b/EventLook/View/MainWindow.xaml
@@ -166,6 +166,8 @@
                                       Command="{Binding DataContext.FilterToSelectedIdCommand, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=DataGrid}}"/>
                             <Separator/>
                             <MenuItem Header="Reset filters" Command="{Binding DataContext.ResetFiltersCommand, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=DataGrid}}"/>
+                            <Separator/>
+                            <MenuItem Header="Copy Message text" Command="{Binding DataContext.CopyMessageTextCommand, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=DataGrid}}"/>
                         </ContextMenu.Items>
                     </ContextMenu>
                 </DataGrid.Resources>

--- a/EventLook/View/MainWindow.xaml
+++ b/EventLook/View/MainWindow.xaml
@@ -43,6 +43,7 @@
             <MenuItem Header="_File">
                 <MenuItem Header="_Open evtx file" Click="MenuItem_FileOpen_Click"/>
                 <Separator />
+                <MenuItem Header="_Launch Windows Event Viewer" Command="{Binding LaunchEventViewerCommand}"/>
                 <MenuItem Header="E_xit" Command="{Binding ExitCommand}" />
             </MenuItem>
             <MenuItem Header="_About" Click="MenuItem_About_Click"/>

--- a/EventLook/View/MainWindow.xaml
+++ b/EventLook/View/MainWindow.xaml
@@ -36,12 +36,13 @@
     <Window.InputBindings>
         <KeyBinding Key="F5" Command="{Binding RefreshCommand}"/>
         <KeyBinding Key="F5" Modifiers="Shift" Command="{Binding CancelCommand}"/>
+        <KeyBinding Key="O" Modifiers="Ctrl" Command="{Binding OpenFileCommand}"/>
     </Window.InputBindings>
     
     <DockPanel>
         <Menu DockPanel.Dock="Top" Background="White">
             <MenuItem Header="_File">
-                <MenuItem Header="_Open evtx file" Click="MenuItem_FileOpen_Click"/>
+                <MenuItem Header="_Open evtx file" InputGestureText="Ctrl+O" Command="{Binding OpenFileCommand}"/>
                 <Separator />
                 <MenuItem Header="_Launch Windows Event Viewer" Command="{Binding LaunchEventViewerCommand}"/>
                 <MenuItem Header="E_xit" Command="{Binding ExitCommand}" />

--- a/EventLook/View/MainWindow.xaml.cs
+++ b/EventLook/View/MainWindow.xaml.cs
@@ -132,17 +132,6 @@ public partial class MainWindow : Window
             dataGrid1.ScrollIntoView(dataGrid1.SelectedItem);
     }
 
-    private void MenuItem_FileOpen_Click(object sender, RoutedEventArgs e)
-    {
-        OpenFileDialog openFileDialog = new()
-        {
-            Filter = "Event Log files (*.evtx)|*.evtx"
-        };
-        if (openFileDialog.ShowDialog() == true)
-        {
-            WeakReferenceMessenger.Default.Send(new FileToBeProcessedMessageToken() { FilePath = openFileDialog.FileName });
-        }
-    }
     private void MenuItem_About_Click(object sender, RoutedEventArgs e)
     {
         AboutControlView about = new();

--- a/EventLook/ViewModel/MainViewModel.cs
+++ b/EventLook/ViewModel/MainViewModel.cs
@@ -3,6 +3,7 @@ using CommunityToolkit.Mvvm.Input;
 using CommunityToolkit.Mvvm.Messaging;
 using EventLook.Model;
 using EventLook.View;
+using Microsoft.Win32;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -318,8 +319,8 @@ public class MainViewModel : ObservableRecipient
     public ICommand FilterToSelectedLevelCommand { get; private set; }
     public ICommand ExcludeSelectedLevelCommand { get; private set; }
     public ICommand FilterToSelectedIdCommand { get; private set; }
+    public ICommand OpenFileCommand { get; private set; }
     public ICommand LaunchEventViewerCommand { get; private set; }
-
 
     private void InitializeCommands()
     {
@@ -335,6 +336,7 @@ public class MainViewModel : ObservableRecipient
         FilterToSelectedLevelCommand = new RelayCommand(FilterToSelectedLevel);
         ExcludeSelectedLevelCommand = new RelayCommand(ExcludeSelectedLevel);
         FilterToSelectedIdCommand = new RelayCommand(FilterToSelectedId);
+        OpenFileCommand = new RelayCommand(OpenFile);
         LaunchEventViewerCommand = new RelayCommand(LaunchEventViewer);
     }
     #endregion
@@ -443,6 +445,17 @@ public class MainViewModel : ObservableRecipient
         ShowWindowService = token.ShowWindowService;
     }
 
+    private void OpenFile()
+    {
+        OpenFileDialog openFileDialog = new()
+        {
+            Filter = "Event Log files (*.evtx)|*.evtx"
+        };
+        if (openFileDialog.ShowDialog() == true)
+        {
+            SelectedLogSource = logSourceMgr.AddEvtx(openFileDialog.FileName);
+        }
+    }
     private void LaunchEventViewer()
     {
         string arg = "";

--- a/EventLook/ViewModel/MainViewModel.cs
+++ b/EventLook/ViewModel/MainViewModel.cs
@@ -318,6 +318,8 @@ public class MainViewModel : ObservableRecipient
     public ICommand FilterToSelectedLevelCommand { get; private set; }
     public ICommand ExcludeSelectedLevelCommand { get; private set; }
     public ICommand FilterToSelectedIdCommand { get; private set; }
+    public ICommand LaunchEventViewerCommand { get; private set; }
+
 
     private void InitializeCommands()
     {
@@ -333,6 +335,7 @@ public class MainViewModel : ObservableRecipient
         FilterToSelectedLevelCommand = new RelayCommand(FilterToSelectedLevel);
         ExcludeSelectedLevelCommand = new RelayCommand(ExcludeSelectedLevel);
         FilterToSelectedIdCommand = new RelayCommand(FilterToSelectedId);
+        LaunchEventViewerCommand = new RelayCommand(LaunchEventViewer);
     }
     #endregion
 
@@ -438,5 +441,21 @@ public class MainViewModel : ObservableRecipient
     private void Handle_ShowWindowServiceMessageToken(ShowWindowServiceMessageToken token)
     {
         ShowWindowService = token.ShowWindowService;
+    }
+
+    private void LaunchEventViewer()
+    {
+        string arg = "";
+        if (SelectedLogSource?.PathType == PathType.FilePath)
+            arg = $"/l:\"{selectedLogSource.Path}\"";
+        else if (selectedLogSource?.PathType == PathType.LogName)
+            arg = $"/c:\"{selectedLogSource.Path}\"";
+
+        Process.Start(new ProcessStartInfo
+        {
+            UseShellExecute = true,
+            FileName = "eventvwr.msc",
+            Arguments = arg,
+        });
     }
 }

--- a/EventLook/ViewModel/MainViewModel.cs
+++ b/EventLook/ViewModel/MainViewModel.cs
@@ -321,6 +321,7 @@ public class MainViewModel : ObservableRecipient
     public ICommand FilterToSelectedIdCommand { get; private set; }
     public ICommand OpenFileCommand { get; private set; }
     public ICommand LaunchEventViewerCommand { get; private set; }
+    public ICommand CopyMessageTextCommand { get; private set; }
 
     private void InitializeCommands()
     {
@@ -338,6 +339,7 @@ public class MainViewModel : ObservableRecipient
         FilterToSelectedIdCommand = new RelayCommand(FilterToSelectedId);
         OpenFileCommand = new RelayCommand(OpenFile);
         LaunchEventViewerCommand = new RelayCommand(LaunchEventViewer);
+        CopyMessageTextCommand = new RelayCommand(CopyMessageText);
     }
     #endregion
 
@@ -470,5 +472,19 @@ public class MainViewModel : ObservableRecipient
             FileName = "eventvwr.msc",
             Arguments = arg,
         });
+    }
+    /// <summary>
+    /// Copies Message text of the selected log to clipboard.
+    /// </summary>
+    private void CopyMessageText()
+    {
+        if (SelectedEventItem == null)
+            return;
+
+        try
+        {
+            Clipboard.SetText(SelectedEventItem.Message);
+        }
+        catch (Exception) { }    // Ignore OpenClipboard exception}
     }
 }


### PR DESCRIPTION
The menu "Launch Windows Event Viewer" tries to launch Event Viewer with the target event log channel/file selected. However, it might happen that Event Viewer is launched with a previously-targeted event log channel selected. 
I'm guessing this is a Windows bug as I also reproed this with launching the same command from Win+R (e.g., eventvwr.msc /c:"Application"). It was same if I use eventvwr.exe instead of .msc. 