### PR TITLE
Add additional identifications in About dialog

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
       run: |
         Remove-Item -Recurse ${{ env.PROJECT_NAME }}\bin\ARM64
         Remove-Item -Recurse ${{ env.PROJECT_NAME }}\bin\x86
-        Remove-Item -Recurse ${{ env.PROJECT_NAME }}\bin\x64\Release\net6.0-windows\win-x64
+        Remove-Item -Recurse ${{ env.PROJECT_NAME }}\bin\x64\Release\net6.0-windows10.0.17763.0\win-x64
     # Save artifacts
     - uses: actions/upload-artifact@v2
       with:

--- a/AboutBoxWpf/AboutControlView.xaml
+++ b/AboutBoxWpf/AboutControlView.xaml
@@ -17,7 +17,6 @@
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
-            <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
 
         <!-- Logo and Title -->
@@ -46,7 +45,7 @@
         <TextBlock x:Name="Description"
 				   Grid.Column="0"
 				   Grid.Row="1"
-				   Margin="15,5,10,0"
+				   Margin="15,5,10,15"
 				   TextWrapping="Wrap"
 				   Text="{Binding Description}"/>
 
@@ -54,25 +53,23 @@
         <Grid Grid.Column="0"
 			  Grid.Row="2"
 			  Margin="10,0">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="Auto" />
-                <ColumnDefinition Width="*" />
-            </Grid.ColumnDefinitions>
-
-            <TextBlock Grid.Column="0"
-					   Grid.Row="0"
-                       Margin="5"
-					   Text="Version: " />
-            <StackPanel Orientation="Horizontal" Grid.Column="1" Grid.Row="0">
-                <Label x:Name="Version" Content="{Binding Version}"/>
-                <Label Content="{Binding VersionAppendix}"/>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+            </Grid.RowDefinitions>
+            
+            <StackPanel Orientation="Horizontal" Grid.Row="0">
+                <TextBlock Margin="5" Text="Version:" />
+                <TextBlock Margin="5" x:Name="Version" Text="{Binding Version}"/>
+                <TextBlock Margin="5" Text="{Binding VersionAppendix}"/>
             </StackPanel>
+            <TextBlock Grid.Row="1" Margin="5,0" Text="{Binding PackageInfoText}"/>
         </Grid>
 
         <!-- Publisher -->
         <Grid Grid.Column="0"
 			  Grid.Row="3"
-			  Margin="10, 20">
+			  Margin="10,20,10,10">
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="Auto" />
@@ -91,16 +88,8 @@
             </Label>
         </Grid>
 
-        <!-- Additional Notes -->
-        <TextBlock x:Name="AdditionalNotes"
-				   Grid.Column="0"
-				   Grid.Row="4"
-				   Margin="15,0,10,10"
-				   TextWrapping="Wrap"
-				   Text="{Binding AdditionalNotes}"/>
-
         <!-- OK button to cancel -->
-        <Button Grid.Column="0" Grid.Row="5" Margin="15" Width="70" HorizontalAlignment="Right"
+        <Button Grid.Column="0" Grid.Row="4" Margin="15" Width="70" HorizontalAlignment="Right"
                 Content="OK" IsCancel="True"></Button>
     </Grid>
 </UserControl>

--- a/AboutBoxWpf/AboutControlView.xaml
+++ b/AboutBoxWpf/AboutControlView.xaml
@@ -63,10 +63,10 @@
 					   Grid.Row="0"
                        Margin="5"
 					   Text="Version: " />
-            <Label x:Name="Version"
-				   Content="{Binding Version}"
-				   Grid.Column="1"
-				   Grid.Row="0" />
+            <StackPanel Orientation="Horizontal" Grid.Column="1" Grid.Row="0">
+                <Label x:Name="Version" Content="{Binding Version}"/>
+                <Label Content="{Binding VersionAppendix}"/>
+            </StackPanel>
         </Grid>
 
         <!-- Publisher -->

--- a/AboutBoxWpf/AboutControlViewModel.cs
+++ b/AboutBoxWpf/AboutControlViewModel.cs
@@ -174,6 +174,23 @@ public class AboutControlViewModel : INotifyPropertyChanged
         }
     }
 
+    private string _PackageInfoText = "";
+    public string PackageInfoText
+    {
+        get
+        {
+            return _PackageInfoText;
+        }
+        set
+        {
+            if (_PackageInfoText != value)
+            {
+                _PackageInfoText = value;
+                OnPropertyChanged("PackageInfoText");
+            }
+        }
+    }
+
     /// <summary>
     /// Gets or sets the publisher logo.
     /// </summary>

--- a/AboutBoxWpf/AboutControlViewModel.cs
+++ b/AboutBoxWpf/AboutControlViewModel.cs
@@ -157,6 +157,23 @@ public class AboutControlViewModel : INotifyPropertyChanged
         }
     }
 
+    private string _VersionAppendix = "";
+    public string VersionAppendix 
+    {
+        get 
+        {
+            return _VersionAppendix;
+        }
+        set 
+        {
+            if (_VersionAppendix != value) 
+            {
+                _VersionAppendix = value;
+                OnPropertyChanged("VersionAppendix");
+            }
+        }
+    }
+
     /// <summary>
     /// Gets or sets the publisher logo.
     /// </summary>

--- a/AboutBoxWpf/AboutControlViewModel.cs
+++ b/AboutBoxWpf/AboutControlViewModel.cs
@@ -26,7 +26,7 @@ public class AboutControlViewModel : INotifyPropertyChanged
         Window.WindowStartupLocation = WindowStartupLocation.CenterOwner;
         Window.SizeToContent = SizeToContent.WidthAndHeight;
         Window.ResizeMode = ResizeMode.NoResize;
-        Window.WindowStyle = WindowStyle.ToolWindow;
+        Window.WindowStyle = WindowStyle.SingleBorderWindow;
 
         Window.ShowInTaskbar = false;
         Window.Title = "About ";

--- a/EventLook/EventLook.csproj
+++ b/EventLook/EventLook.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net6.0-windows10.0.17763.0</TargetFramework>
     <OutputType>WinExe</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <UseWPF>true</UseWPF>

--- a/EventLook/Model/BuildInfo.cs
+++ b/EventLook/Model/BuildInfo.cs
@@ -3,12 +3,23 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.Versioning;
 using System.Text;
 using System.Threading.Tasks;
+using Windows.ApplicationModel;
 
 namespace EventLook.Model;
 internal static class BuildInfo
 {
+    /// <summary>
+    /// Simplified package type to be consumed by About menu.
+    /// </summary>
+    public enum PackageType
+    {
+        NotPackaged,    // Standalone build such as artifact in GitHub.
+        DevPackage,     // Private build of EventLookPackage.
+        Store           // Formal release.
+    }
     /// <summary>
     /// Gets build date (= last write time) of the main DLL of this .NET Core application.
     /// Assuming the process EXE and the main DLL share the same name (e.g., EventLook.exe vs EventLook.dll)
@@ -20,5 +31,32 @@ internal static class BuildInfo
         string dllPath = Path.ChangeExtension(Assembly.GetExecutingAssembly().Location, "dll");
 
         return File.Exists(dllPath) ? File.GetLastWriteTime(dllPath) : DateTime.MaxValue;
+    }
+
+    /// <summary>
+    /// Determines the simplified package type of this application.
+    /// If the environment is very old (like Win8 or very early version of Win10), treats as not packaged.
+    /// </summary>
+    /// <returns></returns>
+    public static PackageType GetPackageType()
+    {
+        if (!OperatingSystem.IsWindowsVersionAtLeast(10, 0, 14393))
+        {
+            return PackageType.NotPackaged;
+        }
+        try
+        {
+            Package package = Package.Current;
+            return package.SignatureKind switch
+            {
+                PackageSignatureKind.None or PackageSignatureKind.Developer or PackageSignatureKind.Enterprise => PackageType.DevPackage,
+                PackageSignatureKind.Store or PackageSignatureKind.System => PackageType.Store,
+                _ => PackageType.NotPackaged,
+            };
+        }
+        catch (Exception)
+        {
+            return PackageType.NotPackaged;
+        }
     }
 }

--- a/EventLook/Model/BuildInfo.cs
+++ b/EventLook/Model/BuildInfo.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EventLook.Model;
+internal static class BuildInfo
+{
+    /// <summary>
+    /// Gets build date (= last write time) of the main DLL of this .NET Core application.
+    /// Assuming the process EXE and the main DLL share the same name (e.g., EventLook.exe vs EventLook.dll)
+    /// and are located in the same folder.
+    /// </summary>
+    /// <returns></returns>
+    public static DateTime GetBuildDate()
+    {
+        string dllPath = Path.ChangeExtension(Assembly.GetExecutingAssembly().Location, "dll");
+
+        return File.Exists(dllPath) ? File.GetLastWriteTime(dllPath) : DateTime.MaxValue;
+    }
+}

--- a/EventLook/Properties/AssemblyInfo.cs
+++ b/EventLook/Properties/AssemblyInfo.cs
@@ -53,5 +53,5 @@ using System.Windows;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.1.0.0")]
+[assembly: AssemblyVersion("1.1.1.0")]
 //[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/EventLook/View/MainWindow.xaml
+++ b/EventLook/View/MainWindow.xaml
@@ -13,7 +13,7 @@
         <Style TargetType="Window">
             <Style.Triggers>
                 <DataTrigger Binding="{Binding IsRunAsAdmin}" Value="False">
-                    <Setter Property="Title" Value="{Binding SelectedLogSource.Path, StringFormat={}{0} - EvetLook}"/>
+                    <Setter Property="Title" Value="{Binding SelectedLogSource.Path, StringFormat={}{0} - EventLook}"/>
                 </DataTrigger>
                 <DataTrigger Binding="{Binding IsRunAsAdmin}" Value="True">
                     <Setter Property="Title" Value="{Binding SelectedLogSource.Path, StringFormat={}{0} - EventLook (Administrator)}"/>

--- a/EventLook/View/MainWindow.xaml.cs
+++ b/EventLook/View/MainWindow.xaml.cs
@@ -146,11 +146,18 @@ public partial class MainWindow : Window
         AboutControlViewModel vm = (AboutControlViewModel)about.FindResource("ViewModel");
         vm.IsSemanticVersioning = true;
         vm.VersionAppendix = $"({BuildInfo.GetBuildDate().ToString("d")})";
+
+        var packageType = BuildInfo.GetPackageType();
+        vm.PackageInfoText =
+            packageType == BuildInfo.PackageType.Store ? "For Microsoft Store" :
+            packageType == BuildInfo.PackageType.DevPackage ? "Developer package" :
+            "Unpackaged app";
+
         vm.ApplicationLogo = new BitmapImage(new Uri("pack://application:,,,/Asset/favicon.ico"));
         vm.PublisherLogo = new BitmapImage(new Uri("pack://application:,,,/Asset/favicon.ico"));
         vm.HyperlinkText = "https://github.com/kmaki565/EventLook";
         vm.Title = "EventLook";
-        vm.AdditionalNotes = "A fast & handy Event Viewer";
+        vm.Description = "A fast & handy Event Viewer";
 
         vm.Window.Content = about;
         vm.Window.ShowDialog();

--- a/EventLook/View/MainWindow.xaml.cs
+++ b/EventLook/View/MainWindow.xaml.cs
@@ -1,6 +1,7 @@
 ﻿using AboutBoxWpf;
 using CommunityToolkit.Mvvm.DependencyInjection;
 using CommunityToolkit.Mvvm.Messaging;
+using EventLook.Model;
 using EventLook.View;
 using EventLook.ViewModel;
 using Microsoft.Win32;
@@ -144,6 +145,7 @@ public partial class MainWindow : Window
         AboutControlView about = new();
         AboutControlViewModel vm = (AboutControlViewModel)about.FindResource("ViewModel");
         vm.IsSemanticVersioning = true;
+        vm.VersionAppendix = $"({BuildInfo.GetBuildDate().ToString("d")})";
         vm.ApplicationLogo = new BitmapImage(new Uri("pack://application:,,,/Asset/favicon.ico"));
         vm.PublisherLogo = new BitmapImage(new Uri("pack://application:,,,/Asset/favicon.ico"));
         vm.HyperlinkText = "https://github.com/kmaki565/EventLook";

--- a/EventLookPackage/Package.appxmanifest
+++ b/EventLookPackage/Package.appxmanifest
@@ -9,7 +9,7 @@
   <Identity
     Name="64247kmaki565.323654BB1C7D"
     Publisher="CN=B5234934-E68F-4911-8E10-60FECC338A02"
-    Version="1.1.0.0" />
+    Version="1.1.1.0" />
 
   <Properties>
     <DisplayName>EventLook</DisplayName>


### PR DESCRIPTION
Shows build date (determined by file time of EventLook.dll) and package type (e.g., Store, developer package, or standalone exe) in the About menu. Not tested yet in older OSes. 

Example of side-loading installation:

![image](https://github.com/kmaki565/EventLook/assets/16055659/c4a48e0b-c9d8-43dd-b374-04d0b0c4abe5)
