### PR TITLE
Fix UI hang

### DIFF
--- a/EventLook/Model/FilterBase.cs
+++ b/EventLook/Model/FilterBase.cs
@@ -20,13 +20,14 @@ public abstract class FilterBase : Monitorable
     }
     /// <summary>
     /// Refreshes filter UI (e.g. populate filter items in a drop down) by loaded events,
-    /// trying to carry over filters user specified.
+    /// If carryOver is true, it'll try to carry over filters user specified (except newly populated checkboxes).
+    /// Otherwise all filters will be cleared (e.g. checkboxes all checked).
     /// </summary>
     /// <param name="events">Loaded event items</param>
-    public virtual void Refresh(IEnumerable<EventItem> events) { }
+    public virtual void Refresh(IEnumerable<EventItem> events, bool carryOver) { }
 
     /// <summary>
-    /// Removes filter and restores the default UI for the Reset button.
+    /// Removes filter and restores the default UI (to be called by "Reset filter" button).
     /// </summary>
     public abstract void Reset();
 

--- a/EventLook/Model/IdFilter.cs
+++ b/EventLook/Model/IdFilter.cs
@@ -35,6 +35,11 @@ public class IdFilter : FilterBase
         }
     }
 
+    public override void Refresh(IEnumerable<EventItem> events, bool carryOver)
+    {
+        if (!carryOver)
+            Reset();
+    }
     public override void Reset()
     {
         IdFilterNum = null;

--- a/EventLook/Model/LevelFilter.cs
+++ b/EventLook/Model/LevelFilter.cs
@@ -25,10 +25,13 @@ public class LevelFilter : FilterBase
         private set;
     }
 
-    public override void Refresh(IEnumerable<EventItem> events)
+    public override void Refresh(IEnumerable<EventItem> events, bool carryOver)
     {
         // Make a copy before clearing
-        var prevFilters = levelFilters.Select(f => new LevelFilterItem { Level = f.Level, Selected = f.Selected }).ToList();
+        var prevFilters = carryOver ?
+            levelFilters.Select(f => new LevelFilterItem { Level = f.Level, Selected = f.Selected }).ToList() :
+            new List<LevelFilterItem>();
+
         levelFilters.Clear();
 
         var distinctLevels = events.Select(e => e.Record.Level).Distinct().OrderBy(lv => lv);

--- a/EventLook/Model/LevelFilter.cs
+++ b/EventLook/Model/LevelFilter.cs
@@ -27,10 +27,8 @@ public class LevelFilter : FilterBase
 
     public override void Refresh(IEnumerable<EventItem> events, bool carryOver)
     {
-        // Make a copy before clearing
-        var prevFilters = carryOver ?
-            levelFilters.Select(f => new LevelFilterItem { Level = f.Level, Selected = f.Selected }).ToList() :
-            new List<LevelFilterItem>();
+        // Remember filters and their selections before clearing (needs ToList)
+        var prevFilters = carryOver ? levelFilters.Select(f => new { f.Level, f.Selected }).ToList() : null;
 
         levelFilters.Clear();
 
@@ -40,7 +38,7 @@ public class LevelFilter : FilterBase
             levelFilters.Add(new LevelFilterItem
             {
                 Level = lv,
-                Selected = prevFilters.FirstOrDefault(f => f.Level == lv)?.Selected ?? true
+                Selected = prevFilters?.FirstOrDefault(f => f.Level == lv)?.Selected ?? true
             });
         }
 

--- a/EventLook/Model/MessageFilter.cs
+++ b/EventLook/Model/MessageFilter.cs
@@ -34,6 +34,11 @@ public class MessageFilter : FilterBase
         }
     }
 
+    public override void Refresh(IEnumerable<EventItem> events, bool carryOver)
+    {
+        if (!carryOver)
+            Reset();
+    }
     public override void Reset()
     {
         MessageFilterText = "";

--- a/EventLook/Model/SourceFilter.cs
+++ b/EventLook/Model/SourceFilter.cs
@@ -29,10 +29,8 @@ public class SourceFilter : FilterBase
 
     public override void Refresh(IEnumerable<EventItem> events, bool carryOver)
     {
-        // Make a copy before clearing
-        var prevFilters = carryOver ?
-            sourceFilters.Select(f => new SourceFilterItem { Name = f.Name, Selected = f.Selected }).ToList() :
-            new List<SourceFilterItem>();
+        // Remember filters and their selections before clearing (needs ToList)
+        var prevFilters = carryOver ? sourceFilters.Select(f => new { f.Name, f.Selected }).ToList() : null;
 
         sourceFilters.Clear();
 
@@ -42,7 +40,7 @@ public class SourceFilter : FilterBase
             sourceFilters.Add(new SourceFilterItem
             {
                 Name = s,
-                Selected = prevFilters.FirstOrDefault(f => f.Name == s)?.Selected ?? true
+                Selected = prevFilters?.FirstOrDefault(f => f.Name == s)?.Selected ?? true
             });
         }
 

--- a/EventLook/Model/SourceFilter.cs
+++ b/EventLook/Model/SourceFilter.cs
@@ -27,10 +27,13 @@ public class SourceFilter : FilterBase
         private set; 
     }
 
-    public override void Refresh(IEnumerable<EventItem> events)
+    public override void Refresh(IEnumerable<EventItem> events, bool carryOver)
     {
         // Make a copy before clearing
-        var prevFilters = sourceFilters.Select(f => new SourceFilterItem { Name = f.Name, Selected = f.Selected }).ToList();
+        var prevFilters = carryOver ?
+            sourceFilters.Select(f => new SourceFilterItem { Name = f.Name, Selected = f.Selected }).ToList() :
+            new List<SourceFilterItem>();
+
         sourceFilters.Clear();
 
         var distinctSources = events.Select(e => e.Record.ProviderName).Distinct().OrderBy(s => s);

--- a/EventLook/View/MainWindow.xaml.cs
+++ b/EventLook/View/MainWindow.xaml.cs
@@ -34,7 +34,13 @@ public partial class MainWindow : Window
         var logPickerWindowService = new ShowWindowService<LogPickerWindow, LogPickerViewModel>() { Owner = this };
         WeakReferenceMessenger.Default.Send(new LogPickerWindowServiceMessageToken() { LogPickerWindowService = logPickerWindowService });
 
-        ContentRendered += (_, _) => { mainViewModel.OnLoaded(); };
+        // It looks like the expander needs expanded once to check "Select All" even if all other checkboxes are checked.
+        Ex1.IsExpanded = true;
+        ContentRendered += (_, _) =>
+        {
+            Ex1.IsExpanded = false;
+            mainViewModel.OnLoaded();
+        };
         mainViewModel.Refreshing += OnRefreshing;
         mainViewModel.Refreshed += OnRefreshed;
 


### PR DESCRIPTION
- Fixes #50 
- Fix: "Select All" not checked even if all other checkboxes are checked

Because of the first fix, UX got slightly different - nothing will be shown until all logs are fetched, when log source selection is changed and a filter was applied in the last source.