### PR TITLE
UX improvement - show events immediately

### DIFF
--- a/EventLook/EventLook.csproj
+++ b/EventLook/EventLook.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <AssemblyTitle>A fast &amp; handy Event Viewer</AssemblyTitle>
-    <AssemblyVersion>1.3.0.0</AssemblyVersion>
+    <AssemblyVersion>1.4.0.0</AssemblyVersion>
     <Description>$(AssemblyTitle)</Description>
     <Copyright>Copyright (C) K. Maki</Copyright>
     <Product>EventLook</Product>

--- a/EventLook/Model/FilterBase.cs
+++ b/EventLook/Model/FilterBase.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -45,7 +46,10 @@ public abstract class FilterBase : Monitorable
     {
         if (isFilterAdded || cvs == null) return;
 
+        SaveSortDescription();
         cvs.Filter += DoFilter;
+        RestoreSortDescription();
+
         isFilterAdded = true;
         FireFilterUpdated(EventArgs.Empty);
     }
@@ -53,7 +57,10 @@ public abstract class FilterBase : Monitorable
     {
         if (!isFilterAdded || cvs == null) return;
 
+        SaveSortDescription();
         cvs.Filter -= DoFilter;
+        RestoreSortDescription();
+
         isFilterAdded = false;
         FireFilterUpdated(EventArgs.Empty);
     }
@@ -79,5 +86,26 @@ public abstract class FilterBase : Monitorable
     protected virtual void FireFilterUpdated(EventArgs e)
     {
         FilterUpdated?.Invoke(this, e);
+    }
+
+    private SortDescription sortDesc;
+    /// <summary>
+    /// Saves the first sort description of the collection view, 
+    /// assuming multiple descriptions cannot be specified from the UI.
+    /// </summary>
+    private void SaveSortDescription()
+    {
+        sortDesc = cvs.View.SortDescriptions.FirstOrDefault();
+    }
+    /// <summary>
+    /// Restores sort description of the view, since apparently 
+    /// it's cleared when the filter event handler is added/removed.
+    /// </summary>
+    private void RestoreSortDescription()
+    {
+        if (sortDesc == default) return;
+        
+        cvs.View.SortDescriptions.Clear();
+        cvs.View.SortDescriptions.Add(sortDesc);
     }
 }

--- a/EventLook/Model/FilterBase.cs
+++ b/EventLook/Model/FilterBase.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -18,58 +17,47 @@ public abstract class FilterBase : Monitorable
     public void SetCvs(CollectionViewSource cvs)
     {
         this.cvs = cvs;
+        this.cvs.Filter += DoFilter;
     }
     /// <summary>
     /// Refreshes filter UI (e.g. populate filter items in a drop down) by loaded events,
-    /// If carryOver is true, it'll try to carry over filters user specified (except newly populated checkboxes).
-    /// Otherwise all filters will be cleared (e.g. checkboxes all checked).
+    /// If reset is true, all filters will be cancelled (e.g. checkboxes all checked).
+    /// Otherwise, it'll try to carry over filters user specified (except newly populated checkboxes).
     /// </summary>
     /// <param name="events">Loaded event items</param>
-    public virtual void Refresh(IEnumerable<EventItem> events, bool carryOver) { }
+    public virtual void Refresh(IEnumerable<EventItem> events, bool reset) { }
 
     /// <summary>
-    /// Removes filter and restores the default UI (to be called by "Reset filter" button).
+    /// Removes filter, but keeps the filter items in the dropdown (if available).
+    /// This is to be called by "Reset filter" button.
     /// </summary>
-    public abstract void Reset();
+    public abstract void Clear();
+    /// <summary>
+    /// Removes filter and filter items in the dropdown (if available).
+    /// </summary>
+    public virtual void Reset()
+    {
+        Clear();
+    }
 
     /// <summary>
     /// Applies filter when the user operates the filter UI.
     /// </summary>
-    public virtual void Apply()
+    public void Apply()
     {
-        RemoveFilter();
-        AddFilter();
+        if (cvs != null)
+        {
+            cvs.View.Refresh();
+            FireFilterUpdated(EventArgs.Empty);
+        }
     }
 
-    private bool isFilterAdded = false;
-    protected void AddFilter()
-    {
-        if (isFilterAdded || cvs == null) return;
-
-        SaveSortDescription();
-        cvs.Filter += DoFilter;
-        RestoreSortDescription();
-
-        isFilterAdded = true;
-        FireFilterUpdated(EventArgs.Empty);
-    }
-    protected void RemoveFilter()
-    {
-        if (!isFilterAdded || cvs == null) return;
-
-        SaveSortDescription();
-        cvs.Filter -= DoFilter;
-        RestoreSortDescription();
-
-        isFilterAdded = false;
-        FireFilterUpdated(EventArgs.Empty);
-    }
     protected void DoFilter(object sender, FilterEventArgs e)
     {
         // Set false if the event does not match to the filter criteria.
         // When using multiple filters, do not explicitly set anything to true.
 
-        if (!(e.Item is EventItem evt))
+        if (e.Item is not EventItem evt)
             e.Accepted = false;
         else if (!IsFilterMatched(evt))
             e.Accepted = false;
@@ -86,26 +74,5 @@ public abstract class FilterBase : Monitorable
     protected virtual void FireFilterUpdated(EventArgs e)
     {
         FilterUpdated?.Invoke(this, e);
-    }
-
-    private SortDescription sortDesc;
-    /// <summary>
-    /// Saves the first sort description of the collection view, 
-    /// assuming multiple descriptions cannot be specified from the UI.
-    /// </summary>
-    private void SaveSortDescription()
-    {
-        sortDesc = cvs.View.SortDescriptions.FirstOrDefault();
-    }
-    /// <summary>
-    /// Restores sort description of the view, since apparently 
-    /// it's cleared when the filter event handler is added/removed.
-    /// </summary>
-    private void RestoreSortDescription()
-    {
-        if (sortDesc == default) return;
-        
-        cvs.View.SortDescriptions.Clear();
-        cvs.View.SortDescriptions.Add(sortDesc);
     }
 }

--- a/EventLook/Model/IdFilter.cs
+++ b/EventLook/Model/IdFilter.cs
@@ -28,19 +28,16 @@ public class IdFilter : FilterBase
             idFilterNum = value;
             NotifyPropertyChanged();
 
-            if (value == null)
-                RemoveFilter();
-            else
-                Apply();
+            Apply();
         }
     }
 
-    public override void Refresh(IEnumerable<EventItem> events, bool carryOver)
+    public override void Refresh(IEnumerable<EventItem> events, bool reset)
     {
-        if (!carryOver)
-            Reset();
+        if (reset)
+            Clear();
     }
-    public override void Reset()
+    public override void Clear()
     {
         IdFilterNum = null;
     }
@@ -50,6 +47,6 @@ public class IdFilter : FilterBase
         if (idFilterNum.HasValue)
             return evt.Record.Id == IdFilterNum.Value;
         else
-            return true;    // Shouldn't come here - null means no filter specified.
+            return true;    // No filter specified.
     }
 }

--- a/EventLook/Model/LevelFilter.cs
+++ b/EventLook/Model/LevelFilter.cs
@@ -25,10 +25,10 @@ public class LevelFilter : FilterBase
         private set;
     }
 
-    public override void Refresh(IEnumerable<EventItem> events, bool carryOver)
+    public override void Refresh(IEnumerable<EventItem> events, bool reset)
     {
         // Remember filters and their selections before clearing (needs ToList)
-        var prevFilters = carryOver ? levelFilters.Select(f => new { f.Level, f.Selected }).ToList() : null;
+        var prevFilters = reset ? null : levelFilters.Select(f => new { f.Level, f.Selected }).ToList();
 
         levelFilters.Clear();
 
@@ -44,18 +44,25 @@ public class LevelFilter : FilterBase
 
         Apply();
     }
-    public override void Reset()
+    public override void Clear()
     {
-        RemoveFilter();
         foreach (var lf in levelFilters)
         {
             lf.Selected = true;
         }
+        Apply();
+    }
+    public override void Reset()
+    {
+        levelFilters.Clear();
     }
 
     protected override bool IsFilterMatched(EventItem evt)
     {
-        return LevelFilters.Where(lf => lf.Selected).Any(lf => lf.Level == evt.Record.Level);
+        if (levelFilters.Count == 0)
+            return true;
+
+        return levelFilters.Where(lf => lf.Selected).Any(lf => lf.Level == evt.Record.Level);
     }
 
     /// <summary>
@@ -64,10 +71,10 @@ public class LevelFilter : FilterBase
     /// <returns>Returns true if success.</returns>
     public bool SetSingleFilter(byte? level)
     {
-        if (LevelFilters.Any(x => x.Level == level) == false)
+        if (levelFilters.Any(x => x.Level == level) == false)
             return false;
 
-        foreach (var filterItem in LevelFilters)
+        foreach (var filterItem in levelFilters)
         {
             filterItem.Selected = (filterItem.Level == level);
         }
@@ -79,10 +86,10 @@ public class LevelFilter : FilterBase
     /// <returns>Returns true if success.</returns>
     public bool UncheckFilter(byte? level)
     {
-        if (LevelFilters.Any(x => x.Level == level) == false)
+        if (levelFilters.Any(x => x.Level == level) == false)
             return false;
 
-        foreach (var filterItem in LevelFilters)
+        foreach (var filterItem in levelFilters)
         {
             if (filterItem.Level == level)
                 filterItem.Selected = false;

--- a/EventLook/Model/MessageFilter.cs
+++ b/EventLook/Model/MessageFilter.cs
@@ -26,26 +26,26 @@ public class MessageFilter : FilterBase
 
             messageFilterText = value;
             NotifyPropertyChanged();
-
-            if (value == "")
-                RemoveFilter();
-            else
-                Apply();
+            
+            Apply();
         }
     }
 
-    public override void Refresh(IEnumerable<EventItem> events, bool carryOver)
+    public override void Refresh(IEnumerable<EventItem> events, bool reset)
     {
-        if (!carryOver)
-            Reset();
+        if (reset)
+            Clear();
     }
-    public override void Reset()
+    public override void Clear()
     {
         MessageFilterText = "";
     }
 
     protected override bool IsFilterMatched(EventItem evt)
     {
+        if (MessageFilterText == "")
+            return true;
+
         // First, make text groups for OR search.
         var filterGroups = MessageFilterText.Split('|').Where(x => !string.IsNullOrWhiteSpace(x));
         foreach (var filterText in filterGroups)

--- a/EventLook/Model/SourceFilter.cs
+++ b/EventLook/Model/SourceFilter.cs
@@ -27,10 +27,10 @@ public class SourceFilter : FilterBase
         private set; 
     }
 
-    public override void Refresh(IEnumerable<EventItem> events, bool carryOver)
+    public override void Refresh(IEnumerable<EventItem> events, bool reset)
     {
         // Remember filters and their selections before clearing (needs ToList)
-        var prevFilters = carryOver ? sourceFilters.Select(f => new { f.Name, f.Selected }).ToList() : null;
+        var prevFilters = reset ? null : sourceFilters.Select(f => new { f.Name, f.Selected }).ToList();
 
         sourceFilters.Clear();
 
@@ -46,18 +46,25 @@ public class SourceFilter : FilterBase
 
         Apply();
     }
-    public override void Reset()
+    public override void Clear()
     {
-        RemoveFilter();
-        foreach (var sf in SourceFilters)
+        foreach (var sf in sourceFilters)
         {
             sf.Selected = true;
         }
+        Apply();
+    }
+    public override void Reset()
+    {
+        sourceFilters.Clear();
     }
 
     protected override bool IsFilterMatched(EventItem evt)
     {
-        return SourceFilters.Where(sf => sf.Selected).Any(sf => String.Compare(sf.Name, evt.Record.ProviderName) == 0);
+        if (sourceFilters.Count == 0)
+            return true;
+
+        return sourceFilters.Where(sf => sf.Selected).Any(sf => string.Equals(sf.Name, evt.Record.ProviderName));
     }
 
     /// <summary>
@@ -67,10 +74,10 @@ public class SourceFilter : FilterBase
     /// <returns>Returns true if success.</returns>
     public bool SetSingleFilter(string name)
     {
-        if (SourceFilters.Any(x => x.Name == name) == false)
+        if (sourceFilters.Any(x => x.Name == name) == false)
             return false;
 
-        foreach (var filterItem in SourceFilters)
+        foreach (var filterItem in sourceFilters)
         {
             filterItem.Selected = (filterItem.Name == name);
         }
@@ -83,10 +90,10 @@ public class SourceFilter : FilterBase
     /// <returns>Returns true if success.</returns>
     public bool UncheckFilter(string name)
     {
-        if (SourceFilters.Any(x => x.Name == name) == false)
+        if (sourceFilters.Any(x => x.Name == name) == false)
             return false;
 
-        foreach (var filterItem in SourceFilters)
+        foreach (var filterItem in sourceFilters)
         {
             if (filterItem.Name == name)
                 filterItem.Selected = false;

--- a/EventLook/View/MainWindow.xaml
+++ b/EventLook/View/MainWindow.xaml
@@ -143,7 +143,7 @@
                     <TextBox x:Name="textBoxMsgFilter" Text="{Binding MsgFilter.MessageFilterText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, Delay=300}"
                              v:TextBoxBehavior.EscapeClearsText="True"
                              Width="180" VerticalContentAlignment="Center" />
-                    <Button Content="Reset filters" Margin="10,0,0,0" Command="{Binding ResetFiltersCommand, Mode=OneWay}"/>
+                    <Button Content="Reset filters" Height="25" Margin="10,0,0,0" Command="{Binding ResetFiltersCommand, Mode=OneWay}"/>
                 </StackPanel>
             </Expander>
 

--- a/EventLook/View/MainWindow.xaml.cs
+++ b/EventLook/View/MainWindow.xaml.cs
@@ -116,6 +116,9 @@ public partial class MainWindow : Window
     private void OnRefreshing()
     {
         isRefreshing = true;
+
+        // When an older event is selected, refreshing entire events causes the DataGrid to keep auto-scrolling.
+        // This is to workaround the issue, but needs to be revisited.
         ScrollToTop();
     }
     private void OnRefreshed()

--- a/EventLook/ViewModel/MainViewModel.cs
+++ b/EventLook/ViewModel/MainViewModel.cs
@@ -356,7 +356,7 @@ public class MainViewModel : ObservableRecipient
     }
     /// <summary>
     /// Gets or sets the CollectionViewSource which is the proxy for the
-    /// collection of Things and the datagrid in which each thing is displayed.
+    /// collection of Events and the datagrid in which each Event is displayed.
     /// </summary>
     private CollectionViewSource CVS { get; set; }
     /// <summary>

--- a/EventLook/ViewModel/MainViewModel.cs
+++ b/EventLook/ViewModel/MainViewModel.cs
@@ -157,7 +157,10 @@ public class MainViewModel : ObservableRecipient
         
         await Task.Run(() => LoadEvents());
 
-        filters.ForEach(f => f.Refresh(Events, reset));
+        // If the log source selection is changed before completing loading events, we don't want to enumerate
+        // the source filter items with the previous log source.
+        if (!IsUpdating)
+            filters.ForEach(f => f.Refresh(Events, reset));
 
         Refreshed?.Invoke();
     }

--- a/EventLookPackage/Package.appxmanifest
+++ b/EventLookPackage/Package.appxmanifest
@@ -9,7 +9,7 @@
   <Identity
     Name="64247kmaki565.323654BB1C7D"
     Publisher="CN=B5234934-E68F-4911-8E10-60FECC338A02"
-    Version="1.3.0.0" />
+    Version="1.4.0.0" />
 
   <Properties>
     <DisplayName>EventLook</DisplayName>


### PR DESCRIPTION
Previously, the app did remove/re-add filters (i.e., unsubscribe/subscribe a filter event) when applying new filters. I think this is inefficient and may cause a performance issue as observed in #50. The app now reuses the filter events throughout the process lifetime. 
The new design naturally fixes #29. 

It can now show some events immediately after log source selection is changed. This was done by removing (resetting) all filters before loading events.