### PR TITLE
Support exclude search in message filter

### DIFF
--- a/EventLook/EventLook.csproj
+++ b/EventLook/EventLook.csproj
@@ -50,7 +50,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.2" />
-    <PackageReference Include="Extended.Wpf.Toolkit" Version="4.5.1" />
+    <PackageReference Include="Extended.Wpf.Toolkit" Version="4.6.0" />
     <PackageReference Include="Microsoft.DotNet.UpgradeAssistant.Extensions.Default.Analyzers" Version="0.4.421302" PrivateAssets="all" />
   </ItemGroup>
   <ItemGroup>

--- a/EventLook/Model/MessageFilter.cs
+++ b/EventLook/Model/MessageFilter.cs
@@ -51,8 +51,12 @@ public class MessageFilter : FilterBase
         foreach (var filterText in filterGroups)
         {
             // Then, do AND search (case-insensitive) for each group. 
+            //TODO: Do just once to build search words to improve performance.
             IEnumerable<string> searchWords = TextHelper.SplitQuotedText(filterText.ToLower());
-            if (searchWords.All(x => evt.Message.ToLower().Contains(x)))
+            List<string> includedWords = searchWords.Where(x => !TextHelper.IsWordToExclude(x)).ToList();
+            List<string> excludedWords = searchWords.Where(x => TextHelper.IsWordToExclude(x)).Select(x => x.Remove(0, 1)).ToList();
+            string target = evt.Message.ToLower();
+            if (excludedWords.All(x => !target.Contains(x)) && includedWords.All(x => target.Contains(x)))
                 return true;
         }
         return false;

--- a/EventLook/Model/Range.cs
+++ b/EventLook/Model/Range.cs
@@ -24,7 +24,7 @@ public class RangeMgr
             new Range() { Text = "Last 7 days", DaysFromNow = 7, IsCustom = false },
             new Range() { Text = "Last 15 days", DaysFromNow = 15, IsCustom = false },
             new Range() { Text = "Last 30 days", DaysFromNow = 30, IsCustom = false },
-            new Range() { Text = "Any time", DaysFromNow = 0, IsCustom = false },
+            new Range() { Text = "All time", DaysFromNow = 0, IsCustom = false },
             new Range() { Text = "Custom range", DaysFromNow = 0, IsCustom = true },
         };
     }
@@ -32,8 +32,8 @@ public class RangeMgr
 
     public Range GetStartupRange()
     {
-        // Default is "Any time".
-        // Note that user's choice "Custom range" is handled as "Any time" at startup as we don't save IsCustom property.
+        // Default is "All time".
+        // Note that user's choice "Custom range" is handled as "All time" at startup as we don't save IsCustom property.
         return Ranges.FirstOrDefault(x => x.DaysFromNow == Properties.Settings.Default.StartupRangeDays) ??
             Ranges.First(x => x.DaysFromNow == 0 && x.IsCustom == false);
     }

--- a/EventLook/Model/TextHelper.cs
+++ b/EventLook/Model/TextHelper.cs
@@ -42,4 +42,9 @@ public static class TextHelper
                    .Where(x => x != "")
             : input.Split(new char[] { ' ', '\t' }, StringSplitOptions.RemoveEmptyEntries);
     }
+
+    public static bool IsWordToExclude(string word)
+    {
+        return word.StartsWith('-') && !word.Contains(' ');
+    }
 }

--- a/EventLook/View/MainWindow.xaml
+++ b/EventLook/View/MainWindow.xaml
@@ -7,7 +7,7 @@
         xmlns:xctk="http://schemas.xceed.com/wpf/xaml/toolkit" xmlns:viewmodel="clr-namespace:EventLook.ViewModel" d:DataContext="{d:DesignInstance Type=viewmodel:MainViewModel}"
         mc:Ignorable="d"
         ResizeMode="CanResizeWithGrip"
-        PreviewKeyDown="Window_PreviewKeyDown">
+        PreviewKeyDown="Window_PreviewKeyDown" d:DesignHeight="640" d:DesignWidth="1100">
     <Window.Style>
         <Style TargetType="Window">
             <Style.Triggers>
@@ -124,12 +124,12 @@
             <Expander x:Name="Ex1" Header="F_ilters" Grid.Row="1" Margin="10,0,0,0" ExpandDirection="Down">
                 <StackPanel Orientation="Horizontal">
                     <TextBlock Text="Source: " Margin="5,0,0,0" VerticalAlignment="Center"/>
-                    <xctk:CheckComboBox Width="220" 
+                    <xctk:CheckComboBox Width="250" 
                             IsSelectAllActive="True" IsAllItemsSelectedContentActive="True"
                             Delimiter=", "
                             ItemsSource="{Binding SourceFilters}" DisplayMemberPath="Name" SelectedMemberPath="Selected"
                             Command="{Binding ApplySourceFilterCommand}"/>
-                    <TextBlock Text="Level: " Margin="5,0,0,0" VerticalAlignment="Center"/>
+                    <TextBlock Text="Level: " Margin="10,0,0,0" VerticalAlignment="Center"/>
                     <xctk:CheckComboBox Width="120" 
                             IsSelectAllActive="True" IsAllItemsSelectedContentActive="True"
                             Delimiter=", "
@@ -142,8 +142,8 @@
                     <TextBlock Text="Message contains: " Margin="10,0,0,0" VerticalAlignment="Center"/>
                     <TextBox x:Name="textBoxMsgFilter" Text="{Binding MsgFilter.MessageFilterText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, Delay=300}"
                              v:TextBoxBehavior.EscapeClearsText="True"
-                             Width="180" VerticalContentAlignment="Center" />
-                    <Button Content="Reset filters" Height="25" Margin="10,0,0,0" Command="{Binding ResetFiltersCommand, Mode=OneWay}"/>
+                             MinWidth="200" VerticalContentAlignment="Center" />
+                    <Button Content="Reset filters" Height="25" Width="70" Margin="15,0,0,0" Command="{Binding ResetFiltersCommand, Mode=OneWay}"/>
                 </StackPanel>
             </Expander>
 

--- a/EventLook/View/MainWindow.xaml
+++ b/EventLook/View/MainWindow.xaml
@@ -125,13 +125,13 @@
                 <StackPanel Orientation="Horizontal">
                     <TextBlock Text="Source: " Margin="5,0,0,0" VerticalAlignment="Center"/>
                     <xctk:CheckComboBox Width="220" 
-                            IsSelectAllActive="True"
+                            IsSelectAllActive="True" IsAllItemsSelectedContentActive="True"
                             Delimiter=", "
                             ItemsSource="{Binding SourceFilters}" DisplayMemberPath="Name" SelectedMemberPath="Selected"
                             Command="{Binding ApplySourceFilterCommand}"/>
                     <TextBlock Text="Level: " Margin="5,0,0,0" VerticalAlignment="Center"/>
                     <xctk:CheckComboBox Width="120" 
-                            IsSelectAllActive="True"
+                            IsSelectAllActive="True" IsAllItemsSelectedContentActive="True"
                             Delimiter=", "
                             ItemsSource="{Binding LevelFilters}" SelectedMemberPath="Selected"
                             Command="{Binding ApplyLevelFilterCommand}"/>

--- a/Tests/EventLookTests.cs
+++ b/Tests/EventLookTests.cs
@@ -3,38 +3,91 @@ using EventLook.Model;
 namespace Tests;
 
 [TestClass]
-public class EventLookTests
+public class SplitText_Tests
 {
-    string input1 = "This is a \"quoted string\" with some   \"quoted  words\" in it.";
-    string[] expected1 = ["This", "is", "a", "quoted string", "with", "some", "quoted  words", "in", "it."];
+    readonly string input1 = "This is a \"quoted string\" with some   \"quoted  words\" in it.";
+    readonly string[] expected1 = ["This", "is", "a", "quoted string", "with", "some", "quoted  words", "in", "it."];
 
-    string input2 = "This is a \"\" with some \"quoted words\" in it.";
-    string[] expected2 = ["This", "is", "a", "with", "some", "quoted words", "in", "it."];
+    readonly string input2 = "This is a \"\" with some \"quoted words\" in it.";
+    readonly string[] expected2 = ["This", "is", "a", "with", "some", "quoted words", "in", "it."];
 
-    string input3 = " \"Those not quoted yet.";
-    string[] expected3 = ["\"Those", "not", "quoted", "yet."];
+    readonly string input3 = " \"Those not quoted yet.";
+    readonly string[] expected3 = ["\"Those", "not", "quoted", "yet."];
 
-    string input4 = ".iu/?!\"Those not quoted yet.";
-    string[] expected4 = [".iu/?!\"Those", "not", "quoted", "yet."];
+    readonly string input4 = ".iu/?!\"Those not quoted yet.";
+    readonly string[] expected4 = [".iu/?!\"Those", "not", "quoted", "yet."];
 
     [TestMethod]
-    public void SplitText_Test1()
+    public void Test1()
     {
         CollectionAssert.AreEqual(expected1, TextHelper.SplitQuotedText(input1).ToArray());
     }
     [TestMethod]
-    public void SplitText_Test2()
+    public void Test2()
     {
         CollectionAssert.AreEqual(expected2, TextHelper.SplitQuotedText(input2).ToArray());
     }
     [TestMethod]
-    public void SplitText_Test3()
+    public void Test3()
     {
         CollectionAssert.AreEqual(expected3, TextHelper.SplitQuotedText(input3).ToArray());
     }
     [TestMethod]
-    public void SplitText_Test4()
+    public void Test4()
     {
         CollectionAssert.AreEqual(expected4, TextHelper.SplitQuotedText(input4).ToArray());
+    }
+}
+
+[TestClass]
+public class IsTextMatched_Tests
+{
+    readonly string[] samplelogs =
+    [
+        "The bootmgr spent 0 ms waiting for user input.",
+        "There are 0x1 boot options on this system.",
+        "The boot type was 0x2.",
+        "The boot menu policy was 0x0.",
+        "The firmware reported boot metrics."
+    ];
+    [TestMethod]
+    public void Test1()
+    {
+        AndSearchMaterial andSearch = new AndSearchMaterial("0x");
+        Assert.IsFalse(TextHelper.IsTextMatched(samplelogs[0], andSearch));
+        Assert.IsTrue(TextHelper.IsTextMatched(samplelogs[1], andSearch));
+        Assert.IsTrue(TextHelper.IsTextMatched(samplelogs[2], andSearch));
+        Assert.IsTrue(TextHelper.IsTextMatched(samplelogs[3], andSearch));
+        Assert.IsFalse(TextHelper.IsTextMatched(samplelogs[4], andSearch));
+    }
+    [TestMethod]
+    public void Test2()
+    {
+        AndSearchMaterial andSearch = new AndSearchMaterial("0 wa ");
+        Assert.IsTrue(TextHelper.IsTextMatched(samplelogs[0], andSearch));
+        Assert.IsFalse(TextHelper.IsTextMatched(samplelogs[1], andSearch));
+        Assert.IsTrue(TextHelper.IsTextMatched(samplelogs[2], andSearch));
+        Assert.IsTrue(TextHelper.IsTextMatched(samplelogs[3], andSearch));
+        Assert.IsFalse(TextHelper.IsTextMatched(samplelogs[4], andSearch));
+    }
+    [TestMethod]
+    public void Test3()
+    {
+        AndSearchMaterial andSearch = new AndSearchMaterial("\"are 0x\"");
+        Assert.IsFalse(TextHelper.IsTextMatched(samplelogs[0], andSearch));
+        Assert.IsTrue(TextHelper.IsTextMatched(samplelogs[1], andSearch));
+        Assert.IsFalse(TextHelper.IsTextMatched(samplelogs[2], andSearch));
+        Assert.IsFalse(TextHelper.IsTextMatched(samplelogs[3], andSearch));
+        Assert.IsFalse(TextHelper.IsTextMatched(samplelogs[4], andSearch));
+    }
+    [TestMethod]
+    public void Test4()
+    {
+        AndSearchMaterial andSearch = new AndSearchMaterial("-was");
+        Assert.IsTrue(TextHelper.IsTextMatched(samplelogs[0], andSearch));
+        Assert.IsTrue(TextHelper.IsTextMatched(samplelogs[1], andSearch));
+        Assert.IsFalse(TextHelper.IsTextMatched(samplelogs[2], andSearch));
+        Assert.IsFalse(TextHelper.IsTextMatched(samplelogs[3], andSearch));
+        Assert.IsTrue(TextHelper.IsTextMatched(samplelogs[4], andSearch));
     }
 }

--- a/Tests/EventLookTests.cs
+++ b/Tests/EventLookTests.cs
@@ -6,16 +6,16 @@ namespace Tests;
 public class EventLookTests
 {
     string input1 = "This is a \"quoted string\" with some   \"quoted  words\" in it.";
-    string[] expected1 = { "This", "is", "a", "quoted string", "with", "some", "quoted  words", "in", "it." };
+    string[] expected1 = ["This", "is", "a", "quoted string", "with", "some", "quoted  words", "in", "it."];
 
     string input2 = "This is a \"\" with some \"quoted words\" in it.";
-    string[] expected2 = { "This", "is", "a", "with", "some", "quoted words", "in", "it." };
+    string[] expected2 = ["This", "is", "a", "with", "some", "quoted words", "in", "it."];
 
     string input3 = " \"Those not quoted yet.";
-    string[] expected3 = { "\"Those", "not", "quoted", "yet." };
+    string[] expected3 = ["\"Those", "not", "quoted", "yet."];
 
     string input4 = ".iu/?!\"Those not quoted yet.";
-    string[] expected4 = { ".iu/?!\"Those", "not", "quoted", "yet." };
+    string[] expected4 = [".iu/?!\"Those", "not", "quoted", "yet."];
 
     [TestMethod]
     public void SplitText_Test1()


### PR DESCRIPTION
You can now exclude logs in the DataGrid by adding `-` to the beginning of the word in the message filter.

For example, if you supply `status -success` in the filter TextBox, logs that contain `status` but do not contain `success` will be displayed.