### PR TITLE
Support fast refresh

### DIFF
--- a/EventLook/Model/DataService.cs
+++ b/EventLook/Model/DataService.cs
@@ -30,8 +30,8 @@ public class DataService : IDataService
             try
             {
                 string sQuery = string.Format(" *[System[TimeCreated[@SystemTime > '{0}' and @SystemTime <= '{1}']]]",
-                    fromTime.ToUniversalTime().ToString("s"),
-                    toTime.ToUniversalTime().ToString("s"));
+                    fromTime.ToUniversalTime().ToString("o"),
+                    toTime.ToUniversalTime().ToString("o"));
 
                 var elQuery = new EventLogQuery(eventSource.Path, eventSource.PathType, sQuery)
                 {

--- a/EventLook/Model/DataService.cs
+++ b/EventLook/Model/DataService.cs
@@ -37,7 +37,7 @@ public class DataService : IDataService
                 {
                     ReverseDirection = true
                 };
-                var reader = new System.Diagnostics.Eventing.Reader.EventLogReader(elQuery);
+                var reader = new EventLogReader(elQuery);
                 var eventRecord = reader.ReadEvent();
                 Debug.WriteLine("Begin Reading");
                 await Task.Run(() =>
@@ -50,7 +50,7 @@ public class DataService : IDataService
                         ++count;
                         if (count % 100 == 0)
                         {
-                            var info = new ProgressInfo(eventRecords.ConvertAll(e => new EventItem(e)), false, isFirst);
+                            var info = new ProgressInfo(eventRecords.ConvertAll(e => new EventItem(e)), isComplete: false, isFirst);
                             cts.Token.ThrowIfCancellationRequested();
                             progress.Report(info);
                             isFirst = false;
@@ -77,7 +77,7 @@ public class DataService : IDataService
             }
             finally
             {
-                var info_comp = new ProgressInfo(eventRecords.ConvertAll(e => new EventItem(e)), true, isFirst, errMsg);
+                var info_comp = new ProgressInfo(eventRecords.ConvertAll(e => new EventItem(e)), isComplete: true, isFirst, errMsg);
                 progress.Report(info_comp);
                 Debug.WriteLine("End Reading");
             }

--- a/EventLook/ViewModel/MainViewModel.cs
+++ b/EventLook/ViewModel/MainViewModel.cs
@@ -320,7 +320,7 @@ public class MainViewModel : ObservableRecipient
         Cancel();
 
         await Update(DataService.ReadEvents(selectedLogSource, 
-            isAppend && (lastLogDate != DateTime.MinValue) ? lastLogDate + TimeSpan.FromSeconds(1) : FromDateTime, //TODO: Better way to avoid duplicate logs.
+            isAppend && (lastLogDate != DateTime.MinValue) ? lastLogDate : FromDateTime,
             ToDateTime,
             progress));
     }
@@ -344,7 +344,6 @@ public class MainViewModel : ObservableRecipient
             if (progressInfo.IsFirst)
                 Events.Clear();
 
-            //TODO: Improve performance with AddRange in ObservableCollection.
             foreach (var evt in progressInfo.LoadedEvents)
             {
                 Events.Add(evt);

--- a/EventLook/ViewModel/MainViewModel.cs
+++ b/EventLook/ViewModel/MainViewModel.cs
@@ -311,7 +311,8 @@ public class MainViewModel : ObservableRecipient
             ToDateTime = (SelectedLogSource.PathType == PathType.FilePath) 
                 ? SelectedLogSource.FileWriteTime
                 : DateTime.Now;
-            FromDateTime = ToDateTime - TimeSpan.FromDays(SelectedRange.DaysFromNow);
+            if (!isAppend)
+                FromDateTime = ToDateTime - TimeSpan.FromDays(SelectedRange.DaysFromNow);
         }
 
         // These seem necessary to ensure DateTimePicker be updated
@@ -323,7 +324,7 @@ public class MainViewModel : ObservableRecipient
         Cancel();
 
         await Update(DataService.ReadEvents(selectedLogSource, 
-            isAppend && (lastLogDate != DateTime.MinValue) ? lastLogDate : FromDateTime,
+            isAppend ? lastLogDate : FromDateTime,
             ToDateTime,
             progress));
     }


### PR DESCRIPTION
When F5 key is pressed or the refresh button is clicked, the app now fetches only events whose `TimeCreated` are newer than the latest event in the stored events, instead of refreshing the entire events. The new events will be inserted into the beginning of `Events` as we read logs from the newest to the oldest.