### PR TITLE
Support auto refresh

### DIFF
--- a/EventLook/EventLook.csproj
+++ b/EventLook/EventLook.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <AssemblyTitle>A fast &amp; handy Event Viewer</AssemblyTitle>
-    <AssemblyVersion>1.4.0.0</AssemblyVersion>
+    <AssemblyVersion>1.5.0.0</AssemblyVersion>
     <Description>$(AssemblyTitle)</Description>
     <Copyright>Copyright (C) K. Maki</Copyright>
     <Product>EventLook</Product>

--- a/EventLook/Model/DataService.cs
+++ b/EventLook/Model/DataService.cs
@@ -11,7 +11,7 @@ namespace EventLook.Model;
 
 public interface IDataService
 {
-    Task<int> ReadEvents(LogSource eventSource, DateTime fromTime, DateTime toTime, IProgress<ProgressInfo> progress);
+    Task<int> ReadEvents(LogSource eventSource, DateTime fromTime, DateTime toTime, bool readFromNew, IProgress<ProgressInfo> progress);
     void Cancel();
     /// <summary>
     /// Subscribes to events in an event log channel. The caller will be reported whenever a new event comes in.
@@ -25,7 +25,7 @@ public interface IDataService
 public class DataService : IDataService
 {
     private CancellationTokenSource cts;
-    public async Task<int> ReadEvents(LogSource eventSource, DateTime fromTime, DateTime toTime, IProgress<ProgressInfo> progress)
+    public async Task<int> ReadEvents(LogSource eventSource, DateTime fromTime, DateTime toTime, bool readFromNew, IProgress<ProgressInfo> progress)
     {
         using (cts = new CancellationTokenSource())
         {
@@ -42,7 +42,7 @@ public class DataService : IDataService
 
                 var elQuery = new EventLogQuery(eventSource.Path, eventSource.PathType, sQuery)
                 {
-                    ReverseDirection = true
+                    ReverseDirection = readFromNew
                 };
                 var reader = new EventLogReader(elQuery);
                 var eventRecord = reader.ReadEvent();

--- a/EventLook/Model/DataService.cs
+++ b/EventLook/Model/DataService.cs
@@ -12,8 +12,15 @@ namespace EventLook.Model;
 public interface IDataService
 {
     Task<int> ReadEvents(LogSource eventSource, DateTime fromTime, DateTime toTime, IProgress<ProgressInfo> progress);
-
     void Cancel();
+    /// <summary>
+    /// Subscribes to events in an event log channel. The caller will be reported whenever a new event comes in.
+    /// </summary>
+    /// <param name="eventSource"></param>
+    /// <param name="handler"></param>
+    /// <returns>True if success.</returns>
+    bool SubscribeEvents(LogSource eventSource, IProgress<ProgressInfo> progress);
+    void UnsubscribeEvents();
 }
 public class DataService : IDataService
 {
@@ -87,6 +94,53 @@ public class DataService : IDataService
     public void Cancel()
     {
         cts.Cancel();
+    }
+
+    private IProgress<ProgressInfo> progress = null;
+    private EventLogWatcher watcher = null;
+    public bool SubscribeEvents(LogSource source, IProgress<ProgressInfo> progress)
+    {
+        if (source.PathType == PathType.FilePath)
+            return false;
+
+        this.progress = progress;
+
+        try
+        {
+            UnsubscribeEvents();
+            watcher = new EventLogWatcher(new EventLogQuery(source.Path, PathType.LogName, "*"));
+            watcher.EventRecordWritten += new EventHandler<EventRecordWrittenEventArgs>(EventRecordWrittenHandler);
+            watcher.Enabled = true;
+            return true;
+        }
+        catch (EventLogException)
+        {
+            return false;
+        }
+    }
+    public void UnsubscribeEvents()
+    {
+        if (watcher != null)
+        {
+            watcher.Enabled = false;
+            watcher.Dispose();
+            watcher = null;
+        }
+    }
+    private void EventRecordWrittenHandler(object sender, EventRecordWrittenEventArgs arg)
+    {
+        if (arg.EventRecord == null)
+            return;
+        try
+        {
+            var item = new EventItem(arg.EventRecord);
+            var info = new ProgressInfo(new List<EventItem> { item }, isComplete: true, isFirst: true);
+            progress?.Report(info);
+        }
+        catch (Exception ex)
+        {
+            progress?.Report(new ProgressInfo(new List<EventItem>(), isComplete: true, isFirst: true, ex.Message));
+        }
     }
 
     /// <summary>

--- a/EventLook/Model/EventItem.cs
+++ b/EventLook/Model/EventItem.cs
@@ -51,10 +51,17 @@ public class EventItem
             Message = "(EventLook) Exception occurred while reading the description:\r\n" + ex.Message;
         }
     }
-    #region Properties
+
     public EventRecord Record { get; set; }
     public DateTime TimeOfEvent { get; }
     public string Message { get; }
     public string MessageOneLine { get { return Regex.Replace(Message, @"[\r\n]+", " "); } }
-    #endregion
+    /// <summary>
+    /// Indicates the time when the event was loaded by the app.
+    /// </summary>
+    public DateTime TimeLoaded { get; set; }
+    /// <summary>
+    /// Indicates if the event is newly loaded.
+    /// </summary>
+    public bool IsNewLoaded { get; set; }
 }

--- a/EventLook/Model/ProcessHelper.cs
+++ b/EventLook/Model/ProcessHelper.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.Eventing.Reader;
+using System.Diagnostics;
 using System.Linq;
 using System.Security.Principal;
 using System.Text;
@@ -7,7 +9,7 @@ using System.Threading.Tasks;
 
 namespace EventLook.Model;
 
-class ProcessHelper
+public static class ProcessHelper
 {
     // https://stackoverflow.com/a/31856353/5461938
     public static bool IsElevated
@@ -17,5 +19,21 @@ class ProcessHelper
             return WindowsIdentity.GetCurrent().Owner
               .IsWellKnown(WellKnownSidType.BuiltinAdministratorsSid);
         }
+    }
+
+    public static void LaunchEventViewer(LogSource logSource)
+    {
+        string arg = "";
+        if (logSource?.PathType == PathType.FilePath && !string.IsNullOrEmpty(logSource?.Path))
+            arg = $"/l:\"{logSource.Path}\"";
+        else if (logSource?.PathType == PathType.LogName && !string.IsNullOrEmpty(logSource?.Path))
+            arg = $"/c:\"{logSource.Path}\"";
+
+        Process.Start(new ProcessStartInfo
+        {
+            UseShellExecute = true,
+            FileName = "eventvwr.msc",
+            Arguments = arg,
+        });
     }
 }

--- a/EventLook/View/Converter.cs
+++ b/EventLook/View/Converter.cs
@@ -173,3 +173,58 @@ public class TimeZoneToOffsetTextConverter : IValueConverter
         throw new NotImplementedException();
     }
 }
+
+/// <summary>
+/// Generates the status text based on the various indicators.
+/// 0: IsUpdating, 1: IsAutoRefreshing, 2: IsAppend, 3: LoadedEventCount, 4: AppendCount, 5: LastElapsedTime, 6: ErrorMessage
+/// </summary>
+public class StatusTextConverter : IMultiValueConverter
+{
+    public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
+    {
+        if (values[0] is bool isUpdating && values[1] is bool isAutoRefreshing && values[2] is bool isAppend
+            && values[3] is int loadedEventCount && values[4] is int appendCount
+            && values[5] is TimeSpan lastEpasedTime && values[6] is string errorMessage)
+        {
+            if (isUpdating)
+                return $"Loading {loadedEventCount} events... {errorMessage}";
+            else if (isAutoRefreshing)
+                return $"{loadedEventCount} events loaded. Waiting for new events... {errorMessage}";
+            else
+                return isAppend
+                    ? $"{loadedEventCount} ({appendCount} new) events loaded. {errorMessage}"
+                    : $"{loadedEventCount} events loaded. ({lastEpasedTime.TotalSeconds:F1} sec) {errorMessage}";  // 1 digit after decimal point
+        }
+        else
+            throw new ArgumentException("Arguments not matched to this converter.");
+    }
+
+    public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)
+    {
+        throw new NotImplementedException();
+    }
+}
+/// <summary>
+/// Generates the filter info text based on the various indicators.
+/// 0: IsUpdating, 1: AreEventsFiltered, 2: VisibleEventCount
+/// </summary>
+public class FilterInfoTextConverter : IMultiValueConverter
+{
+    public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
+    {
+        if (values[0] is bool isUpdating && values[1] is bool areEventsFiltered && values[2] is int visibleEventCount)
+        {
+            if (isUpdating)
+                return "";
+            else
+                return areEventsFiltered ? $" {visibleEventCount} events matched to the filter(s)." : "";
+        }
+        else
+            throw new ArgumentException("Arguments not matched to this converter.");
+    }
+
+    public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/EventLook/View/MainWindow.xaml
+++ b/EventLook/View/MainWindow.xaml
@@ -3,8 +3,10 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:xctk="http://schemas.xceed.com/wpf/xaml/toolkit" 
         xmlns:v="clr-namespace:EventLook.View"
-        xmlns:xctk="http://schemas.xceed.com/wpf/xaml/toolkit" xmlns:viewmodel="clr-namespace:EventLook.ViewModel" d:DataContext="{d:DesignInstance Type=viewmodel:MainViewModel}"
+        xmlns:viewmodel="clr-namespace:EventLook.ViewModel"
+        d:DataContext="{d:DesignInstance Type=viewmodel:MainViewModel}"
         mc:Ignorable="d"
         ResizeMode="CanResizeWithGrip"
         PreviewKeyDown="Window_PreviewKeyDown" d:DesignHeight="640" d:DesignWidth="1100">
@@ -207,8 +209,13 @@
                     </Style>
                 </DataGrid.CellStyle>
                 <DataGrid.RowStyle>
-                    <Style TargetType="DataGridRow" BasedOn="{StaticResource {x:Type DataGridRow}}">
+                    <Style TargetType="DataGridRow">
                         <Setter Property="ContextMenu" Value="{StaticResource dataGridContextMenu}" />
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding IsNewLoaded}" Value="True">
+                                <Setter Property="Background" Value="Yellow"/>
+                            </DataTrigger>
+                        </Style.Triggers>
                     </Style>
                 </DataGrid.RowStyle>
                 <DataGrid.InputBindings>

--- a/EventLook/View/MainWindow.xaml
+++ b/EventLook/View/MainWindow.xaml
@@ -35,6 +35,8 @@
         <v:InverseBooleanConverter x:Key="InverseBooleanConverter" />
         <v:UtcToAnotherTimeZoneStringConverter x:Key="UtcToAnotherTimeZoneStringConverter"/>
         <v:TimeZoneToOffsetTextConverter x:Key="TimeZoneToOffsetTextConverter"/>
+        <v:StatusTextConverter x:Key="StatusTextConverter"/>
+        <v:FilterInfoTextConverter x:Key="FilterInfoTextConverter"/>
         <!-- This next line instantiates a CollectionViewSource with the collection of Events as its collection of objects-->
         <CollectionViewSource Source="{Binding Events}" x:Key="X_CVS"/>
     </Window.Resources>
@@ -64,8 +66,28 @@
         <StatusBar DockPanel.Dock="Bottom" Background="WhiteSmoke">
             <StatusBarItem>
                 <StackPanel Orientation="Horizontal">
-                    <TextBlock Text="{Binding StatusText}" />
-                    <TextBlock Text="{Binding FilterInfoText}" />
+                    <TextBlock>
+                        <TextBlock.Text>
+                            <MultiBinding Converter="{StaticResource StatusTextConverter}">
+                                <Binding Path="IsUpdating"/>
+                                <Binding Path="IsAutoRefreshing"/>
+                                <Binding Path="IsAppend"/>
+                                <Binding Path="LoadedEventCount"/>
+                                <Binding Path="AppendCount"/>
+                                <Binding Path="LastElapsedTime"/>
+                                <Binding Path="ErrorMessage"/>
+                            </MultiBinding>
+                        </TextBlock.Text>
+                    </TextBlock>
+                    <TextBlock>
+                        <TextBlock.Text>
+                            <MultiBinding Converter="{StaticResource FilterInfoTextConverter}">
+                                <Binding Path="IsUpdating"/>
+                                <Binding Path="AreEventsFiltered"/>
+                                <Binding Path="VisibleEventCount"/>
+                            </MultiBinding>
+                        </TextBlock.Text>
+                    </TextBlock>
                 </StackPanel>
             </StatusBarItem>
         </StatusBar>

--- a/EventLook/View/MainWindow.xaml
+++ b/EventLook/View/MainWindow.xaml
@@ -54,7 +54,11 @@
                 <MenuItem Header="_Launch Windows Event Viewer" Command="{Binding LaunchEventViewerCommand}"/>
                 <MenuItem Header="E_xit" Command="{Binding ExitCommand}" />
             </MenuItem>
-            <MenuItem Header="_Options" Command="{Binding OpenSettingsCommand}" />
+            <MenuItem Header="_Options">
+                <MenuItem Header="_Auto Refresh" IsCheckable="True" IsChecked="{Binding IsAutoRefreshEnabled}"/>
+                <Separator />
+                <MenuItem Header="_Settings..." Command="{Binding OpenSettingsCommand}" />
+            </MenuItem> 
             <MenuItem Header="_About" Click="MenuItem_About_Click"/>
         </Menu>
         <StatusBar DockPanel.Dock="Bottom" Background="WhiteSmoke">

--- a/EventLook/View/SettingsWindow.xaml
+++ b/EventLook/View/SettingsWindow.xaml
@@ -7,7 +7,7 @@
         xmlns:viewmodel="clr-namespace:EventLook.ViewModel"
         d:DataContext="{d:DesignInstance Type=viewmodel:SettingsViewModel}"
         mc:Ignorable="d"
-        Title="Options" Height="360" Width="450" Background="WhiteSmoke">
+        Title="Settings" Height="360" Width="450" Background="WhiteSmoke">
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition />

--- a/EventLook/ViewModel/MainViewModel.cs
+++ b/EventLook/ViewModel/MainViewModel.cs
@@ -99,6 +99,7 @@ public class MainViewModel : ObservableRecipient
 
             if (readyToRefresh)
             {
+                DataService.UnsubscribeEvents();
                 Refresh(reset: true);
             }
         }
@@ -366,12 +367,14 @@ public class MainViewModel : ObservableRecipient
             isLastReadSuccess = Events.Any() && progressInfo.Message == "";
             if (isLastReadSuccess)
             {
-                //TODO: Fast refresh should be done once, or we'll miss events that came during loading the entire logs.
+                // Fast refresh should be done once before enabling auto refresh.
+                // Otherwise we'll miss events that came during loading the entire logs.
+                if (!isAppend)
+                    Refresh(reset: false, append: true);
                 DataService.SubscribeEvents(SelectedLogSource, progressAutoRefresh);
                 isAutoRefreshing = true;
                 UpdateStatusText();
             }
-            //TODO: Unsubscribe after source change, before loading the new source events.
         }
     }
 

--- a/EventLook/ViewModel/MainViewModel.cs
+++ b/EventLook/ViewModel/MainViewModel.cs
@@ -429,7 +429,7 @@ public class MainViewModel : ObservableRecipient
             if (progressInfo.IsFirst)
                 AppendCount = 0;
 
-            AppendCount += InsertEvents(progressInfo.LoadedEvents);
+            AppendCount += InsertEvents(progressInfo.LoadedEvents, startPosition: AppendCount);
         }
         else
         {
@@ -464,19 +464,19 @@ public class MainViewModel : ObservableRecipient
     {
         if (progressInfo.LoadedEvents.Any())
         {
-            InsertEvents(progressInfo.LoadedEvents);
+            InsertEvents(progressInfo.LoadedEvents);    // Single event should be loaded at a time.
             LoadedEventCount = Events.Count;
             filters.ForEach(f => f.Refresh(Events, reset: false));
         }
     }
-    private int InsertEvents(IEnumerable<EventItem> events)
+    private int InsertEvents(IEnumerable<EventItem> events, int startPosition = 0)
     {
         int count = 0;
         foreach (var evt in events)
         {
             evt.IsNewLoaded = true;
             evt.TimeLoaded = DateTime.Now;
-            Events.Insert(count, evt);    // We read logs from the newest to the oldest.
+            Events.Insert(startPosition + count, evt);    // We read logs from the newest to the oldest.
             count++;
         }
         if (count > 0 && !newLoadedUpdateTimer.IsEnabled)

--- a/EventLook/ViewModel/MainViewModel.cs
+++ b/EventLook/ViewModel/MainViewModel.cs
@@ -332,7 +332,7 @@ public class MainViewModel : ObservableRecipient
         OpenFileCommand = new RelayCommand(OpenFile);
         OpenLogPickerCommand = new RelayCommand(OpenLogPicker);
         OpenSettingsCommand = new RelayCommand(OpenSettings);
-        LaunchEventViewerCommand = new RelayCommand(LaunchEventViewer);
+        LaunchEventViewerCommand = new RelayCommand(() => ProcessHelper.LaunchEventViewer(SelectedLogSource));
         CopyMessageTextCommand = new RelayCommand(CopyMessageText);
     }
     #endregion
@@ -580,21 +580,6 @@ public class MainViewModel : ObservableRecipient
 
         readyToRefresh = true;
         SelectedRange = Ranges.FirstOrDefault(r => r.Text == newSettings.SelectedRange.Text);   // Fire Refresh
-    }
-    private void LaunchEventViewer()
-    {
-        string arg = "";
-        if (SelectedLogSource?.PathType == PathType.FilePath)
-            arg = $"/l:\"{selectedLogSource.Path}\"";
-        else if (selectedLogSource?.PathType == PathType.LogName)
-            arg = $"/c:\"{selectedLogSource.Path}\"";
-
-        Process.Start(new ProcessStartInfo
-        {
-            UseShellExecute = true,
-            FileName = "eventvwr.msc",
-            Arguments = arg,
-        });
     }
     /// <summary>
     /// Copies Message text of the selected log to clipboard.

--- a/EventLook/ViewModel/MainViewModel.cs
+++ b/EventLook/ViewModel/MainViewModel.cs
@@ -171,6 +171,8 @@ public class MainViewModel : ObservableRecipient
             {
                 DataService.UnsubscribeEvents();
                 isAutoRefreshing = false;
+                isAppend = false;
+                UpdateStatusText();
             }
         }
     }
@@ -469,8 +471,8 @@ public class MainViewModel : ObservableRecipient
             FilterInfoText = "";
         else
         {
-            int visibleRowCounts = CVS.View.Cast<object>().Count(); // This must be run in the main thread.
-            FilterInfoText = (visibleRowCounts == Events.Count) ? "" : $" {visibleRowCounts} events matched to the filter(s).";
+            int visibleRowCount = CVS.View.Cast<object>().Count(); // This must be run in the main thread.
+            FilterInfoText = (visibleRowCount == Events.Count) ? "" : $" {visibleRowCount} events matched to the filter(s).";
         }
     }
     /// <summary>
@@ -593,6 +595,6 @@ public class MainViewModel : ObservableRecipient
         {
             Clipboard.SetText(SelectedEventItem.Message);
         }
-        catch (Exception) { }    // Ignore OpenClipboard exception}
+        catch (Exception) { }    // Ignore OpenClipboard exception
     }
 }

--- a/EventLookPackage/Package.appxmanifest
+++ b/EventLookPackage/Package.appxmanifest
@@ -9,7 +9,7 @@
   <Identity
     Name="64247kmaki565.323654BB1C7D"
     Publisher="CN=B5234934-E68F-4911-8E10-60FECC338A02"
-    Version="1.4.0.0" />
+    Version="1.5.0.0" />
 
   <Properties>
     <DisplayName>EventLook</DisplayName>


### PR DESCRIPTION
Implemented auto refresh by [subscribing to events](https://learn.microsoft.com/en-us/previous-versions/bb671202(v=vs.90)?redirectedfrom=MSDN). 
Also added coloring events that have been newly loaded by fast refresh (F5) or auto refresh. New events are highlighted in yellow for 5 seconds.
You can turn on auto refresh from Options. There is no persistent setting for auto refresh for now. When auto refresh is enabled, the refresh button will be disabled. 

![image](https://github.com/kmaki565/EventLook/assets/16055659/30ecbba5-c430-4626-a71c-f6a38f114206)
