### PR TITLE
Display record count & improvements

### DIFF
--- a/EventLook/EventLook.csproj
+++ b/EventLook/EventLook.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <AssemblyTitle>A fast &amp; handy Event Viewer</AssemblyTitle>
-    <AssemblyVersion>1.5.0.0</AssemblyVersion>
+    <AssemblyVersion>1.5.1.0</AssemblyVersion>
     <Description>$(AssemblyTitle)</Description>
     <Copyright>Copyright (C) K. Maki</Copyright>
     <Product>EventLook</Product>

--- a/EventLook/Model/DataService.cs
+++ b/EventLook/Model/DataService.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.Eventing.Reader;
-using System.Diagnostics.Tracing;
 using System.Linq;
 using System.Text;
 using System.Threading;
@@ -73,7 +72,7 @@ public class DataService : IDataService
                                 reader.Seek(eventRecord.Bookmark, 1);   // Reset the position to last successful read + 1.
                                 reader.BatchSize /= 2;  // Halve the 2nd param of EvtNext Win32 API to be called.
                                 retryCount++;
-                                Debug.WriteLine($"Retry #{retryCount}. Last successful-read event's RecordId: {eventRecord.RecordId}, Time: {eventRecord.TimeCreated}");
+                                Debug.WriteLine($"Retry #{retryCount}. Last successful-read event's RecordId: {eventRecord.RecordId}, Time: {eventRecord.TimeCreated?.ToString("yyyy-MM-dd HH:mm:ss.fff")}");
                                 continue;
                             }
                             else

--- a/EventLook/Model/DataService.cs
+++ b/EventLook/Model/DataService.cs
@@ -70,7 +70,8 @@ public class DataService : IDataService
                             if (ex.HResult == WIN32ERROR_RPC_S_INVALID_BOUND && retryCount < 3 && eventRecord?.Bookmark != null)
                             {
                                 reader.Seek(eventRecord.Bookmark, 1);   // Reset the position to last successful read + 1.
-                                reader.BatchSize /= 2;  // Halve the 2nd param of EvtNext Win32 API to be called.
+                                if (reader.BatchSize > 1)
+                                    reader.BatchSize /= 2;  // Halve the 2nd param of EvtNext Win32 API to be called.
                                 retryCount++;
                                 Debug.WriteLine($"Retry #{retryCount}. Last successful-read event's RecordId: {eventRecord.RecordId}, Time: {eventRecord.TimeCreated?.ToString("yyyy-MM-dd HH:mm:ss.fff")}");
                                 continue;

--- a/EventLook/Model/EnumerableExtensions.cs
+++ b/EventLook/Model/EnumerableExtensions.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EventLook.Model;
+public static class EnumerableExtensions
+{
+    /// <summary>
+    /// Disposes all items in the sequence, i.e., releases unmanaged resources associated with the items.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="seq"></param>
+    public static void DisposeAll<T>(this IEnumerable<T> seq) where T : IDisposable
+    {
+        foreach (T item in seq)
+            item?.Dispose();
+    }
+}

--- a/EventLook/Model/EventItem.cs
+++ b/EventLook/Model/EventItem.cs
@@ -12,7 +12,7 @@ namespace EventLook.Model;
 /// Represents a event to display. 
 /// Could not inherit EventLogRecord as it doesn't have a public constructor.
 /// </summary>
-public class EventItem
+public class EventItem : IDisposable
 {
     public EventItem(EventRecord eventRecord)
     {
@@ -64,4 +64,6 @@ public class EventItem
     /// Indicates if the event is newly loaded.
     /// </summary>
     public bool IsNewLoaded { get; set; }
+
+    public void Dispose() => Record.Dispose();
 }

--- a/EventLook/Model/Progress.cs
+++ b/EventLook/Model/Progress.cs
@@ -6,19 +6,17 @@ using System.Threading.Tasks;
 
 namespace EventLook.Model;
 
-public class ProgressInfo
+public class ProgressInfo(IReadOnlyList<EventItem> eventItems, bool isComplete, bool isFirst, int totalEventCount = 0, string message = "")
 {
-    public ProgressInfo(IReadOnlyList<EventItem> eventItems, bool isComplete, bool isFirst, string message = "")
-    {
-        LoadedEvents = eventItems;
-        IsComplete = isComplete;
-        IsFirst = isFirst;
-        Message = message;
-    }
+    public IReadOnlyList<EventItem> LoadedEvents { get; } = eventItems;
 
-    public IReadOnlyList<EventItem> LoadedEvents { get; }
-
-    public bool IsComplete { get; }
-    public bool IsFirst { get; }
-    public string Message { get; set; }
+    public bool IsComplete { get; } = isComplete;
+    public bool IsFirst { get; } = isFirst;
+    /// <summary>
+    /// Record count information for the local Event Log. 
+    /// Can be 0 if the count is not determined yet or not applicable. 
+    /// For example, when auto refresh is on, or for a .evtx file, it's always 0.
+    /// </summary>
+    public int RecordCountInfo { get; } = totalEventCount;
+    public string Message { get; } = message;
 }

--- a/EventLook/View/Converter.cs
+++ b/EventLook/View/Converter.cs
@@ -176,18 +176,20 @@ public class TimeZoneToOffsetTextConverter : IValueConverter
 
 /// <summary>
 /// Generates the status text based on the various indicators.
-/// 0: IsUpdating, 1: IsAutoRefreshing, 2: IsAppend, 3: LoadedEventCount, 4: AppendCount, 5: LastElapsedTime, 6: ErrorMessage
+/// 0: IsUpdating, 1: IsAutoRefreshing, 2: IsAppend, 3: LoadedEventCount, 4: TotalEventCount, 5: AppendCount, 6: LastElapsedTime, 7: ErrorMessage
 /// </summary>
 public class StatusTextConverter : IMultiValueConverter
 {
     public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
     {
         if (values[0] is bool isUpdating && values[1] is bool isAutoRefreshing && values[2] is bool isAppend
-            && values[3] is int loadedEventCount && values[4] is int appendCount
-            && values[5] is TimeSpan lastEpasedTime && values[6] is string errorMessage)
+            && values[3] is int loadedEventCount && values[4] is int totalEventCount && values[5] is int appendCount
+            && values[6] is TimeSpan lastEpasedTime && values[7] is string errorMessage)
         {
             if (isUpdating)
-                return $"Loading {loadedEventCount} events... {errorMessage}";
+                return totalEventCount > 0 
+                    ? $"Loading {loadedEventCount}/{totalEventCount} events... {errorMessage}"
+                    : $"Loading {loadedEventCount} events... {errorMessage}";
             else if (isAutoRefreshing)
                 return $"{loadedEventCount} events loaded. Waiting for new events... {errorMessage}";
             else

--- a/EventLook/View/MainWindow.xaml
+++ b/EventLook/View/MainWindow.xaml
@@ -75,6 +75,7 @@
                                 <Binding Path="IsAutoRefreshing"/>
                                 <Binding Path="IsAppend"/>
                                 <Binding Path="LoadedEventCount"/>
+                                <Binding Path="TotalEventCount"/>
                                 <Binding Path="AppendCount"/>
                                 <Binding Path="LastElapsedTime"/>
                                 <Binding Path="ErrorMessage"/>

--- a/EventLook/View/MainWindow.xaml.cs
+++ b/EventLook/View/MainWindow.xaml.cs
@@ -163,6 +163,7 @@ public partial class MainWindow : Window
         vm.HyperlinkText = "https://github.com/kmaki565/EventLook";
 
         vm.Window.Content = about;
+        vm.Window.Owner = this; // To make the child window always on top of this window.
         vm.Window.ShowDialog();
     }
 }

--- a/EventLook/ViewModel/MainViewModel.cs
+++ b/EventLook/ViewModel/MainViewModel.cs
@@ -437,7 +437,10 @@ public class MainViewModel : ObservableRecipient
         else
         {
             if (progressInfo.IsFirst)
+            {
+                Events.DisposeAll();
                 Events.Clear();
+            }
 
             foreach (var evt in progressInfo.LoadedEvents)
             {

--- a/EventLook/ViewModel/MainViewModel.cs
+++ b/EventLook/ViewModel/MainViewModel.cs
@@ -390,10 +390,6 @@ public class MainViewModel : ObservableRecipient
             if (!IsAppend)
                 FromDateTime = ToDateTime - TimeSpan.FromDays(SelectedRange.DaysFromNow);
         }
-
-        // These seem necessary to ensure DateTimePicker be updated
-        OnPropertyChanged(nameof(FromDateTime));
-        OnPropertyChanged(nameof(ToDateTime));
     }
     private async Task LoadEvents()
     {
@@ -465,6 +461,9 @@ public class MainViewModel : ObservableRecipient
             InsertEvents(progressInfo.LoadedEvents);    // Single event should be loaded at a time.
             LoadedEventCount = Events.Count;
             filters.ForEach(f => f.Refresh(Events, reset: false));
+            // If the range is like "Last x days", just adjust appearance of the date time picker.
+            if (!SelectedRange.IsCustom && SelectedRange.DaysFromNow != 0)
+                ToDateTime = DateTime.Now;
         }
     }
     private void TurnOnAutoRefresh()

--- a/EventLook/ViewModel/MainViewModel.cs
+++ b/EventLook/ViewModel/MainViewModel.cs
@@ -149,6 +149,9 @@ public class MainViewModel : ObservableRecipient
     private int loadedEventCount = 0;
     public int LoadedEventCount { get => loadedEventCount; set => SetProperty(ref loadedEventCount, value); }
 
+    private int totalEventCount = 0;
+    public int TotalEventCount { get => totalEventCount; set => SetProperty(ref totalEventCount, value); }
+
     private bool isAppend = false;
     public bool IsAppend { get => isAppend; set => SetProperty(ref isAppend, value); }
 
@@ -408,6 +411,7 @@ public class MainViewModel : ObservableRecipient
         {
             ongoingTask = task;
             stopwatch.Restart();
+            TotalEventCount = 0;
             if (!IsAppend)
                 LoadedEventCount = 0;
             IsUpdating = true;
@@ -442,6 +446,8 @@ public class MainViewModel : ObservableRecipient
         }
 
         LoadedEventCount = Events.Count;
+        // Disregard unless the range is "All time".
+        TotalEventCount = (SelectedRange.DaysFromNow == 0 && !SelectedRange.IsCustom) ? progressInfo.RecordCountInfo : 0;
         ErrorMessage = progressInfo.Message;
 
         if (progressInfo.IsComplete)
@@ -473,6 +479,7 @@ public class MainViewModel : ObservableRecipient
         if (!IsAppend)
             Refresh(reset: false, append: true);
         DataService.SubscribeEvents(SelectedLogSource, progressAutoRefresh);
+        TotalEventCount = 0;
         IsAutoRefreshing = true;
     }
     private void TurnOffAutoRefresh()

--- a/EventLookPackage/Package.appxmanifest
+++ b/EventLookPackage/Package.appxmanifest
@@ -9,7 +9,7 @@
   <Identity
     Name="64247kmaki565.323654BB1C7D"
     Publisher="CN=B5234934-E68F-4911-8E10-60FECC338A02"
-    Version="1.5.0.0" />
+    Version="1.5.1.0" />
 
   <Properties>
     <DisplayName>EventLook</DisplayName>

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ The inbox Windows Event Viewer is a great app that provides comprehensive functi
 - Overview events with Event Log messages
 - Asynchronous event fetching for quick glance
 - Provides quicker sort, specifying time range, and filters
+- Supports auto refresh with new events highlighted
 - Provides access to all Event Logs in local machine, including Applications and Services Logs
 - Supports .evtx file (open from Explorer or drag & drop .evtx file)
 - Double click to view event details in XML format


### PR DESCRIPTION
New features:
- Display record count while loading all events in local Event Log
- Workaround for an issue where reading logs stops with "The array bounds are invalid." error
- Improve memory usage. However, I found it can reduce more (drastically) if I dispose `EventRecord` (a .NET class which holds a Win32 event instance) in `EventItem` (my class) after it's loaded. We may need to be able to fetch the data again when it's needed (e.g., view the event XML).

Fixes #63