### PR TITLE
Reduce memory usage and add up/down buttons in detail window

### DIFF
--- a/EventLook/App.config
+++ b/EventLook/App.config
@@ -40,6 +40,9 @@
       <setting name="ShowsMillisec" serializeAs="String">
         <value>False</value>
       </setting>
+      <setting name="ShowsRecordId" serializeAs="String">
+        <value>False</value>
+      </setting>
     </EventLook.Properties.Settings>
   </userSettings>
 </configuration>

--- a/EventLook/EventLook.csproj
+++ b/EventLook/EventLook.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <AssemblyTitle>A fast &amp; handy Event Viewer</AssemblyTitle>
-    <AssemblyVersion>1.5.1.0</AssemblyVersion>
+    <AssemblyVersion>1.6.0.0</AssemblyVersion>
     <Description>$(AssemblyTitle)</Description>
     <Copyright>Copyright (C) K. Maki</Copyright>
     <Product>EventLook</Product>

--- a/EventLook/Model/DataService.cs
+++ b/EventLook/Model/DataService.cs
@@ -92,6 +92,7 @@ public class DataService : IDataService
                             cts.Token.ThrowIfCancellationRequested();
                             progress.Report(info);
                             isFirst = false;
+                            eventRecords.DisposeAll();
                             eventRecords.Clear();
                         }
                     }
@@ -117,7 +118,7 @@ public class DataService : IDataService
             {
                 var info_comp = new ProgressInfo(eventRecords.ConvertAll(e => new EventItem(e)), isComplete: true, isFirst, totalCount, errMsg);
                 progress.Report(info_comp);
-                eventRecord?.Dispose();
+                eventRecords.DisposeAll();
                 reader?.Dispose();
                 Debug.WriteLine("End Reading");
             }

--- a/EventLook/Model/DataService.cs
+++ b/EventLook/Model/DataService.cs
@@ -11,23 +11,25 @@ namespace EventLook.Model;
 
 public interface IDataService
 {
-    Task<int> ReadEvents(LogSource logSource, DateTime fromTime, DateTime toTime, bool readFromNew, IProgress<ProgressInfo> progress);
+    Task<int> ReadEvents(LogSource source, DateTime fromTime, DateTime toTime, bool readFromNew, IProgress<ProgressInfo> progress);
     void Cancel();
     /// <summary>
     /// Subscribes to events in an event log channel. The caller will be reported whenever a new event comes in.
     /// </summary>
-    /// <param name="logSource"></param>
+    /// <param name="source"></param>
     /// <param name="handler"></param>
     /// <returns>True if success.</returns>
-    bool SubscribeEvents(LogSource logSource, IProgress<ProgressInfo> progress);
+    bool SubscribeEvents(LogSource source, IProgress<ProgressInfo> progress);
     void UnsubscribeEvents();
 }
 public class DataService : IDataService
 {
+    private LogSource logSource;
     private CancellationTokenSource cts;
     const int WIN32ERROR_RPC_S_INVALID_BOUND = unchecked((int)0x800706C6);
-    public async Task<int> ReadEvents(LogSource logSource, DateTime fromTime, DateTime toTime, bool readFromNew, IProgress<ProgressInfo> progress)
+    public async Task<int> ReadEvents(LogSource source, DateTime fromTime, DateTime toTime, bool readFromNew, IProgress<ProgressInfo> progress)
     {
+        logSource = source;
         using (cts = new CancellationTokenSource())
         {
             // Event records to be sent to the ViewModel
@@ -44,7 +46,7 @@ public class DataService : IDataService
                     fromTime.ToUniversalTime().ToString("o"),
                     toTime.ToUniversalTime().ToString("o"));
 
-                var elQuery = new EventLogQuery(logSource.Path, logSource.PathType, sQuery)
+                var elQuery = new EventLogQuery(source.Path, source.PathType, sQuery)
                 {
                     ReverseDirection = readFromNew
                 };
@@ -52,7 +54,7 @@ public class DataService : IDataService
 
                 // Asynchronously get the record count info.
                 // The count is valid only when "All time" is selected for a Event Log on the local machine.
-                _ = Task.Run(() => totalCount = GetRecordCount(logSource));
+                _ = Task.Run(() => totalCount = GetRecordCount(source));
 
                 reader = new EventLogReader(elQuery);
                 await Task.Run(() =>
@@ -88,7 +90,7 @@ public class DataService : IDataService
                         count++;
                         if (count % 100 == 0)
                         {
-                            var info = new ProgressInfo(eventRecords.ConvertAll(e => new EventItem(e)), isComplete: false, isFirst, totalCount);
+                            var info = new ProgressInfo(eventRecords.ConvertAll(e => new EventItem(source, e)), isComplete: false, isFirst, totalCount);
                             cts.Token.ThrowIfCancellationRequested();
                             progress.Report(info);
                             isFirst = false;
@@ -116,7 +118,7 @@ public class DataService : IDataService
             }
             finally
             {
-                var info_comp = new ProgressInfo(eventRecords.ConvertAll(e => new EventItem(e)), isComplete: true, isFirst, totalCount, errMsg);
+                var info_comp = new ProgressInfo(eventRecords.ConvertAll(e => new EventItem(source, e)), isComplete: true, isFirst, totalCount, errMsg);
                 progress.Report(info_comp);
                 eventRecords.DisposeAll();
                 reader?.Dispose();
@@ -137,6 +139,7 @@ public class DataService : IDataService
         if (source.PathType == PathType.FilePath)
             return false;
 
+        this.logSource = source;
         this.progress = progress;
 
         try
@@ -167,7 +170,7 @@ public class DataService : IDataService
             return;
         try
         {
-            var item = new EventItem(arg.EventRecord);
+            var item = new EventItem(logSource, arg.EventRecord);
             var info = new ProgressInfo(new List<EventItem> { item }, isComplete: true, isFirst: true);
             progress?.Report(info);
         }

--- a/EventLook/Model/DataService.cs
+++ b/EventLook/Model/DataService.cs
@@ -145,7 +145,7 @@ public class DataService : IDataService
         try
         {
             UnsubscribeEvents();
-            watcher = new EventLogWatcher(new EventLogQuery(source.Path, PathType.LogName, "*"));
+            watcher = new EventLogWatcher(source.Path);
             watcher.EventRecordWritten += new EventHandler<EventRecordWrittenEventArgs>(EventRecordWrittenHandler);
             watcher.Enabled = true;
             return true;

--- a/EventLook/Model/EventItem.cs
+++ b/EventLook/Model/EventItem.cs
@@ -14,10 +14,9 @@ namespace EventLook.Model;
 /// </summary>
 public class EventItem : IDisposable
 {
-    private readonly LogSource logSource;
     public EventItem(LogSource logSource, EventRecord eventRecord)
     {
-        this.logSource = logSource;
+        LogSource = logSource;
         Record = eventRecord;
         TimeOfEvent = eventRecord.TimeCreated?.ToUniversalTime() ?? DateTime.MinValue.ToUniversalTime();
         try
@@ -54,6 +53,7 @@ public class EventItem : IDisposable
         }
     }
 
+    public LogSource LogSource { get; }
     public EventRecord Record { get; }
     public DateTime TimeOfEvent { get; }
     public string Message { get; }
@@ -83,7 +83,7 @@ public class EventItem : IDisposable
     {
         if (_xml == null && Record.RecordId.HasValue)
         {
-            EventLogQuery query = new(logSource.Path, logSource.PathType, $"*[System/EventRecordID={Record.RecordId.Value}]");
+            EventLogQuery query = new(LogSource.Path, LogSource.PathType, $"*[System/EventRecordID={Record.RecordId.Value}]");
             EventLogReader reader = null;
             EventRecord eventRecord = null;
             try

--- a/EventLook/Model/EventItem.cs
+++ b/EventLook/Model/EventItem.cs
@@ -17,7 +17,6 @@ public class EventItem : IDisposable
     public EventItem(EventRecord eventRecord)
     {
         Record = eventRecord;
-        RecordId = eventRecord.RecordId;
         TimeOfEvent = eventRecord.TimeCreated?.ToUniversalTime() ?? DateTime.MinValue.ToUniversalTime();
         try
         {
@@ -54,7 +53,6 @@ public class EventItem : IDisposable
     }
 
     public EventRecord Record { get; }
-    public long? RecordId { get; }
     public DateTime TimeOfEvent { get; }
     public string Message { get; }
     public string MessageOneLine { get { return Regex.Replace(Message, @"[\r\n]+", " "); } }
@@ -67,7 +65,11 @@ public class EventItem : IDisposable
     /// </summary>
     public bool IsNewLoaded { get; set; }
 
-    public void Dispose() => Record.Dispose();
+    public void Dispose()
+    {
+        Record.Dispose();
+        GC.SuppressFinalize(this);
+    }
 
     private string _xml;
     /// <summary>
@@ -79,9 +81,9 @@ public class EventItem : IDisposable
     /// <returns></returns>
     public string GetXml(LogSource logSource)
     {
-        if (_xml == null && RecordId.HasValue)
+        if (_xml == null && Record.RecordId.HasValue)
         {
-            EventLogQuery query = new(logSource.Path, logSource.PathType, $"*[System/EventRecordID={RecordId.Value}]");
+            EventLogQuery query = new(logSource.Path, logSource.PathType, $"*[System/EventRecordID={Record.RecordId.Value}]");
             EventLogReader reader = null;
             EventRecord eventRecord = null;
             try

--- a/EventLook/Model/EventItem.cs
+++ b/EventLook/Model/EventItem.cs
@@ -14,8 +14,10 @@ namespace EventLook.Model;
 /// </summary>
 public class EventItem : IDisposable
 {
-    public EventItem(EventRecord eventRecord)
+    private readonly LogSource logSource;
+    public EventItem(LogSource logSource, EventRecord eventRecord)
     {
+        this.logSource = logSource;
         Record = eventRecord;
         TimeOfEvent = eventRecord.TimeCreated?.ToUniversalTime() ?? DateTime.MinValue.ToUniversalTime();
         try
@@ -71,15 +73,13 @@ public class EventItem : IDisposable
         GC.SuppressFinalize(this);
     }
 
-    private string _xml;
     /// <summary>
     /// Fetches the XML representation of the event from log source and event record ID.
     /// If the XML is already fetched, it returns the cached XML. 
     /// Returns null if XML cannot be fetched.
     /// </summary>
-    /// <param name="logSource"></param>
-    /// <returns></returns>
-    public string GetXml(LogSource logSource)
+    private string _xml;
+    public string GetXml()
     {
         if (_xml == null && Record.RecordId.HasValue)
         {

--- a/EventLook/Model/EventItem.cs
+++ b/EventLook/Model/EventItem.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Diagnostics.Eventing.Reader;
 using System.Linq;
-using System.Reflection.PortableExecutable;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
@@ -71,6 +70,13 @@ public class EventItem : IDisposable
     public void Dispose() => Record.Dispose();
 
     private string _xml;
+    /// <summary>
+    /// Fetches the XML representation of the event from log source and event record ID.
+    /// If the XML is already fetched, it returns the cached XML. 
+    /// Returns null if XML cannot be fetched.
+    /// </summary>
+    /// <param name="logSource"></param>
+    /// <returns></returns>
     public string GetXml(LogSource logSource)
     {
         if (_xml == null && RecordId.HasValue)
@@ -84,7 +90,7 @@ public class EventItem : IDisposable
                 eventRecord = reader.ReadEvent();
                 if (eventRecord != null)
                 {
-                    _xml = eventRecord.ToXml();
+                    _xml = TextHelper.FormatXml(eventRecord.ToXml());
                 }
             }
             finally

--- a/EventLook/Properties/Settings.Designer.cs
+++ b/EventLook/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace EventLook.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.8.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.9.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
@@ -55,6 +55,18 @@ namespace EventLook.Properties {
             }
             set {
                 this["ShowsMillisec"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool ShowsRecordId {
+            get {
+                return ((bool)(this["ShowsRecordId"]));
+            }
+            set {
+                this["ShowsRecordId"] = value;
             }
         }
     }

--- a/EventLook/Properties/Settings.settings
+++ b/EventLook/Properties/Settings.settings
@@ -11,5 +11,8 @@
     <Setting Name="ShowsMillisec" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
+    <Setting Name="ShowsRecordId" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/EventLook/View/Converter.cs
+++ b/EventLook/View/Converter.cs
@@ -230,3 +230,21 @@ public class FilterInfoTextConverter : IMultiValueConverter
         throw new NotImplementedException();
     }
 }
+
+public class SelectedEventsTextConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        if (value is int count)
+        {
+            return count > 1 ? $"{count} events selected" : "";
+        }
+        else
+            throw new ArgumentException("Argument must be an integer.");
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/EventLook/View/DetailWindow.xaml
+++ b/EventLook/View/DetailWindow.xaml
@@ -5,10 +5,10 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:EventLook.View" xmlns:viewmodel="clr-namespace:EventLook.ViewModel" d:DataContext="{d:DesignInstance Type=viewmodel:DetailViewModel}"
         mc:Ignorable="d"
-        FocusManager.FocusedElement="{Binding ElementName=EventXml}"
+        FocusManager.FocusedElement="{Binding ElementName=TextBoxXml}"
         Title="Event Details" Height="450" Width="800">
     <Grid>
-        <TextBox Name="EventXml" Text="{Binding FormattedXml, Mode=OneWay}"
+        <TextBox Name="TextBoxXml" Text="{Binding EventXml, Mode=OneWay}"
                  IsReadOnly="True" IsReadOnlyCaretVisible="True"
                  VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto"/>
     </Grid>

--- a/EventLook/View/DetailWindow.xaml
+++ b/EventLook/View/DetailWindow.xaml
@@ -6,10 +6,16 @@
         xmlns:local="clr-namespace:EventLook.View" xmlns:viewmodel="clr-namespace:EventLook.ViewModel" d:DataContext="{d:DesignInstance Type=viewmodel:DetailViewModel}"
         mc:Ignorable="d"
         FocusManager.FocusedElement="{Binding ElementName=TextBoxXml}"
-        Title="Event Details" Height="450" Width="800">
+        Title="Event Details" Height="530" Width="900">
     <Grid>
-        <TextBox Name="TextBoxXml" Text="{Binding EventXml, Mode=OneWay}"
+        <DockPanel>
+            <StackPanel DockPanel.Dock="Right" VerticalAlignment="Center" HorizontalAlignment="Center">
+                <Button Command="{Binding UpCommand}" FontFamily="Segoe UI Symbol" Content="&#xE110;" FontSize="15" Width="30" Height="30" Margin="10"/>
+                <Button Command="{Binding DownCommand}" FontFamily="Segoe UI Symbol" Content="&#xE1FD;" FontSize="15" Width="30" Height="30" Margin="10"/>
+            </StackPanel>
+            <TextBox Name="TextBoxXml" Text="{Binding EventXml, Mode=OneWay}"
                  IsReadOnly="True" IsReadOnlyCaretVisible="True"
-                 VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto"/>
+                 VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto" Margin="10,10,0,10"/>
+        </DockPanel>
     </Grid>
 </Window>

--- a/EventLook/View/MainWindow.xaml
+++ b/EventLook/View/MainWindow.xaml
@@ -224,6 +224,7 @@
                     <KeyBinding Key="Enter" Command="{Binding OpenDetailsCommand}" />
                 </DataGrid.InputBindings>
                 <DataGrid.Columns>
+                    <DataGridTextColumn Header="RecordID" Binding="{Binding Record.RecordId}" Visibility="Collapsed"/>
                     <DataGridTextColumn SortMemberPath="TimeOfEvent">
                         <DataGridTextColumn.Binding>
                             <MultiBinding Converter="{StaticResource UtcToAnotherTimeZoneStringConverter}">

--- a/EventLook/View/MainWindow.xaml
+++ b/EventLook/View/MainWindow.xaml
@@ -40,6 +40,7 @@
         <v:TimeZoneToOffsetTextConverter x:Key="TimeZoneToOffsetTextConverter"/>
         <v:StatusTextConverter x:Key="StatusTextConverter"/>
         <v:FilterInfoTextConverter x:Key="FilterInfoTextConverter"/>
+        <v:SelectedEventsTextConverter x:Key="SelectedEventsTextConverter"/>
         <!-- This next line instantiates a CollectionViewSource with the collection of Events as its collection of objects-->
         <CollectionViewSource Source="{Binding Events}" x:Key="X_CVS"/>
         <DataGridTextColumn x:Key="RecordIdColumn" Header="Record ID" Binding="{Binding Record.RecordId}" Visibility="{Binding DataContext.ShowsRecordId, Source={x:Reference _window}, Converter={StaticResource BooleanToVisibilityConverter}}"/>
@@ -94,6 +95,9 @@
                         </TextBlock.Text>
                     </TextBlock>
                 </StackPanel>
+            </StatusBarItem>
+            <StatusBarItem HorizontalAlignment="Right" Margin="10,0">
+                <TextBlock Text="{Binding ElementName=dataGrid1, Path=SelectedItems.Count, Converter={StaticResource SelectedEventsTextConverter}}"/>
             </StatusBarItem>
         </StatusBar>
 

--- a/EventLook/View/MainWindow.xaml
+++ b/EventLook/View/MainWindow.xaml
@@ -1,4 +1,5 @@
 ﻿<Window x:Class="EventLook.View.MainWindow"
+        Name="_window"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -41,6 +42,7 @@
         <v:FilterInfoTextConverter x:Key="FilterInfoTextConverter"/>
         <!-- This next line instantiates a CollectionViewSource with the collection of Events as its collection of objects-->
         <CollectionViewSource Source="{Binding Events}" x:Key="X_CVS"/>
+        <DataGridTextColumn x:Key="RecordIdColumn" Header="Record ID" Binding="{Binding Record.RecordId}" Visibility="{Binding DataContext.ShowsRecordId, Source={x:Reference _window}, Converter={StaticResource BooleanToVisibilityConverter}}"/>
     </Window.Resources>
     <Window.InputBindings>
         <KeyBinding Key="F5" Command="{Binding RefreshCommand}"/>
@@ -224,7 +226,7 @@
                     <KeyBinding Key="Enter" Command="{Binding OpenDetailsCommand}" />
                 </DataGrid.InputBindings>
                 <DataGrid.Columns>
-                    <DataGridTextColumn Header="RecordID" Binding="{Binding Record.RecordId}" Visibility="Collapsed"/>
+                    <StaticResource ResourceKey="RecordIdColumn"/>
                     <DataGridTextColumn SortMemberPath="TimeOfEvent">
                         <DataGridTextColumn.Binding>
                             <MultiBinding Converter="{StaticResource UtcToAnotherTimeZoneStringConverter}">

--- a/EventLook/View/SettingsWindow.xaml
+++ b/EventLook/View/SettingsWindow.xaml
@@ -41,6 +41,7 @@
                                   DisplayMemberPath="Text" SelectedValuePath="Text"/>
                     </StackPanel>
                     <CheckBox Content="Show milliseconds for Time of event" Margin="10,8" IsChecked="{Binding ShowsMillisec}"/>
+                    <CheckBox Content="Show Record ID column" Margin="10,8" IsChecked="{Binding ShowsRecordId}"/>
                 </StackPanel>
             </TabItem>
         </TabControl>

--- a/EventLook/ViewModel/DetailViewModel.cs
+++ b/EventLook/ViewModel/DetailViewModel.cs
@@ -12,11 +12,19 @@ namespace EventLook.ViewModel;
 
 public class DetailViewModel : ObservableObject
 {
+    /// <summary>
+    /// VM for the detail window.
+    /// Receives the main view of the events to walk through the events.
+    /// </summary>
     private readonly ICollectionView _view;
-    public DetailViewModel(EventItem eventItem, ICollectionView view)
+    private int position;
+    public DetailViewModel(ICollectionView view)
     {
-        Event = eventItem;
         _view = view;
+        Event = (EventItem)_view.CurrentItem;
+        // Save my position in case multiple detail windows are open.
+        position = _view.CurrentPosition;
+
         UpCommand = new RelayCommand(() => Move(isUp: true), IsNotFirst);
         DownCommand = new RelayCommand(() => Move(isUp: false), IsNotLast);
     }
@@ -41,18 +49,18 @@ public class DetailViewModel : ObservableObject
 
     private bool IsNotFirst()
     {
-        return _view.CurrentItem != null && _view.CurrentPosition > 0;
+        return Event != null && position > 0;
     }
     private bool IsNotLast()
     {
-        return _view.CurrentItem != null && _view.CurrentPosition < _view.Cast<object>().Count() - 1;
+        return Event != null && position < _view.Cast<object>().Count() - 1;
     }
     private void Move(bool isUp)
     {
         if (isUp && IsNotFirst())
-            _view.MoveCurrentToPrevious();
+            _view.MoveCurrentToPosition(--position);
         else if (!isUp && IsNotLast())
-            _view.MoveCurrentToNext();
+            _view.MoveCurrentToPosition(++position);
         else
             return;
 

--- a/EventLook/ViewModel/DetailViewModel.cs
+++ b/EventLook/ViewModel/DetailViewModel.cs
@@ -7,8 +7,8 @@ using System.Threading.Tasks;
 
 namespace EventLook.ViewModel;
 
-public class DetailViewModel(EventItem eventItem, LogSource logSource)
+public class DetailViewModel(EventItem eventItem)
 {
     public EventItem Event { get; set; } = eventItem;
-    public string EventXml { get => Event.GetXml(logSource) ?? "Could not retrieve XML."; }
+    public string EventXml { get => Event.GetXml() ?? "Could not retrieve XML."; }
 }

--- a/EventLook/ViewModel/DetailViewModel.cs
+++ b/EventLook/ViewModel/DetailViewModel.cs
@@ -7,12 +7,18 @@ using System.Threading.Tasks;
 
 namespace EventLook.ViewModel;
 
-public class DetailViewModel
+public class DetailViewModel(EventItem eventItem, LogSource logSource)
 {
-    public DetailViewModel(EventItem eventItem)
+    public EventItem Event { get; set; } = eventItem;
+    public string FormattedXml
     {
-        Event = eventItem;
+        get
+        {
+            string xml = Event.GetXml(logSource);
+            if (string.IsNullOrEmpty(xml))
+                return "Could not retrieve XML.";
+
+            return TextHelper.FormatXml(xml);
+        }
     }
-    public EventItem Event { get; set; }
-    public string FormattedXml { get { return TextHelper.FormatXml(Event.Record.ToXml()); } }
 }

--- a/EventLook/ViewModel/DetailViewModel.cs
+++ b/EventLook/ViewModel/DetailViewModel.cs
@@ -10,15 +10,5 @@ namespace EventLook.ViewModel;
 public class DetailViewModel(EventItem eventItem, LogSource logSource)
 {
     public EventItem Event { get; set; } = eventItem;
-    public string FormattedXml
-    {
-        get
-        {
-            string xml = Event.GetXml(logSource);
-            if (string.IsNullOrEmpty(xml))
-                return "Could not retrieve XML.";
-
-            return TextHelper.FormatXml(xml);
-        }
-    }
+    public string EventXml { get => Event.GetXml(logSource) ?? "Could not retrieve XML."; }
 }

--- a/EventLook/ViewModel/DetailViewModel.cs
+++ b/EventLook/ViewModel/DetailViewModel.cs
@@ -25,8 +25,8 @@ public class DetailViewModel : ObservableObject
         // Save my position in case multiple detail windows are open.
         position = _view.CurrentPosition;
 
-        UpCommand = new RelayCommand(() => Move(isUp: true), IsNotFirst);
-        DownCommand = new RelayCommand(() => Move(isUp: false), IsNotLast);
+        UpCommand = new RelayCommand(() => Move(isUp: true), CanMoveUp);
+        DownCommand = new RelayCommand(() => Move(isUp: false), CanMoveDown);
     }
 
     private EventItem _event;
@@ -47,22 +47,26 @@ public class DetailViewModel : ObservableObject
     public IRelayCommand UpCommand { get; private set; }
     public IRelayCommand DownCommand { get; private set; }
 
-    private bool IsNotFirst()
+    private bool CanMoveUp()
     {
-        return Event != null && position > 0;
+        if (_view.CurrentItem is EventItem ev && Event?.LogSource == ev.LogSource && position > 0 && position < _view.Cast<object>().Count())
+            return true;
+        else
+            return false;
     }
-    private bool IsNotLast()
+    private bool CanMoveDown()
     {
-        return Event != null && position < _view.Cast<object>().Count() - 1;
+        if (_view.CurrentItem is EventItem ev && Event?.LogSource == ev.LogSource && position < _view.Cast<object>().Count() - 1)
+            return true;
+        else
+            return false;
     }
     private void Move(bool isUp)
     {
-        if (isUp && IsNotFirst())
+        if (isUp)
             _view.MoveCurrentToPosition(--position);
-        else if (!isUp && IsNotLast())
+        else 
             _view.MoveCurrentToPosition(++position);
-        else
-            return;
 
         Event = (EventItem)_view.CurrentItem;
         UpdateCanExecute();

--- a/EventLook/ViewModel/DetailViewModel.cs
+++ b/EventLook/ViewModel/DetailViewModel.cs
@@ -1,14 +1,68 @@
-﻿using EventLook.Model;
+﻿using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using EventLook.Model;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
 namespace EventLook.ViewModel;
 
-public class DetailViewModel(EventItem eventItem)
+public class DetailViewModel : ObservableObject
 {
-    public EventItem Event { get; set; } = eventItem;
-    public string EventXml { get => Event.GetXml() ?? "Could not retrieve XML."; }
+    private readonly ICollectionView _view;
+    public DetailViewModel(EventItem eventItem, ICollectionView view)
+    {
+        Event = eventItem;
+        _view = view;
+        UpCommand = new RelayCommand(() => Move(isUp: true), IsNotFirst);
+        DownCommand = new RelayCommand(() => Move(isUp: false), IsNotLast);
+    }
+
+    private EventItem _event;
+    public EventItem Event
+    {
+        get => _event;
+        set
+        {
+            if (value != _event)
+            {
+                _event = value;
+                OnPropertyChanged();
+                OnPropertyChanged(nameof(EventXml));
+            }
+        }
+    }
+    public string EventXml { get => Event?.GetXml() ?? "Could not retrieve Event XML."; }
+    public IRelayCommand UpCommand { get; private set; }
+    public IRelayCommand DownCommand { get; private set; }
+
+    private bool IsNotFirst()
+    {
+        return _view.CurrentItem != null && _view.CurrentPosition > 0;
+    }
+    private bool IsNotLast()
+    {
+        return _view.CurrentItem != null && _view.CurrentPosition < _view.Cast<object>().Count() - 1;
+    }
+    private void Move(bool isUp)
+    {
+        if (isUp && IsNotFirst())
+            _view.MoveCurrentToPrevious();
+        else if (!isUp && IsNotLast())
+            _view.MoveCurrentToNext();
+        else
+            return;
+
+        Event = (EventItem)_view.CurrentItem;
+        UpdateCanExecute();
+    }
+
+    private void UpdateCanExecute()
+    {
+        UpCommand?.NotifyCanExecuteChanged();
+        DownCommand?.NotifyCanExecuteChanged();
+    }
 }

--- a/EventLook/ViewModel/MainViewModel.cs
+++ b/EventLook/ViewModel/MainViewModel.cs
@@ -284,7 +284,7 @@ public class MainViewModel : ObservableRecipient
     }
     private void OpenDetails()
     {
-        var detailVm = new DetailViewModel(SelectedEventItem, SelectedLogSource);
+        var detailVm = new DetailViewModel(SelectedEventItem);
         DetailWindowService.Show(detailVm);
     }
     private void FilterToSelectedSource()

--- a/EventLook/ViewModel/MainViewModel.cs
+++ b/EventLook/ViewModel/MainViewModel.cs
@@ -284,7 +284,7 @@ public class MainViewModel : ObservableRecipient
     }
     private void OpenDetails()
     {
-        var detailVm = new DetailViewModel(SelectedEventItem);
+        var detailVm = new DetailViewModel(SelectedEventItem, CVS.View);
         DetailWindowService.Show(detailVm);
     }
     private void FilterToSelectedSource()

--- a/EventLook/ViewModel/MainViewModel.cs
+++ b/EventLook/ViewModel/MainViewModel.cs
@@ -284,7 +284,7 @@ public class MainViewModel : ObservableRecipient
     }
     private void OpenDetails()
     {
-        var detailVm = new DetailViewModel(SelectedEventItem);
+        var detailVm = new DetailViewModel(SelectedEventItem, SelectedLogSource);
         DetailWindowService.Show(detailVm);
     }
     private void FilterToSelectedSource()

--- a/EventLook/ViewModel/MainViewModel.cs
+++ b/EventLook/ViewModel/MainViewModel.cs
@@ -288,7 +288,10 @@ public class MainViewModel : ObservableRecipient
     }
     private void OpenDetails()
     {
-        var detailVm = new DetailViewModel(SelectedEventItem, CVS.View);
+        if (SelectedEventItem == null)
+            return;
+
+        var detailVm = new DetailViewModel(CVS.View);
         DetailWindowService.Show(detailVm);
     }
     private void FilterToSelectedSource()

--- a/EventLook/ViewModel/MainViewModel.cs
+++ b/EventLook/ViewModel/MainViewModel.cs
@@ -44,6 +44,7 @@ public class MainViewModel : ObservableRecipient
         TimeZones = new ObservableCollection<TimeZoneInfo>(TimeZoneInfo.GetSystemTimeZones());
         SelectedTimeZone = TimeZones.FirstOrDefault(x => x.Id == TimeZoneInfo.Local.Id);
         ShowsMillisec = Properties.Settings.Default.ShowsMillisec;
+        ShowsRecordId = Properties.Settings.Default.ShowsRecordId;
 
         progress = new Progress<ProgressInfo>(ProgressCallback); // Needs to instantiate in UI thread
         progressAutoRefresh = new Progress<ProgressInfo>(AutoRefreshCallback);
@@ -182,6 +183,9 @@ public class MainViewModel : ObservableRecipient
     public TimeZoneInfo SelectedTimeZone { get => selectedTimeZone; set => SetProperty(ref selectedTimeZone, value); }
     
     public bool ShowsMillisec { get; set; }
+
+    private bool showsRecordId;
+    public bool ShowsRecordId { get => showsRecordId; set => SetProperty(ref showsRecordId, value); }
 
     private readonly bool isRunAsAdmin;
     public bool IsRunAsAdmin { get => isRunAsAdmin; }
@@ -596,7 +600,8 @@ public class MainViewModel : ObservableRecipient
             LogSources = LogSources.ToList(),
             Ranges = Ranges.ToList(),
             SelectedRange = rangeMgr.GetStartupRange(),
-            ShowsMillisec = ShowsMillisec
+            ShowsMillisec = ShowsMillisec,
+            ShowsRecordId = ShowsRecordId
         };
         var openSettingsVm = new SettingsViewModel(LogPickerWindowService, originalSettings);
         string previousLogPath = SelectedLogSource?.Path;
@@ -611,10 +616,12 @@ public class MainViewModel : ObservableRecipient
         Properties.Settings.Default.StartupLogNames = newSettings.LogSources.Select(x => x.Path).ToList();
         Properties.Settings.Default.StartupRangeDays = newSettings.SelectedRange.DaysFromNow;
         Properties.Settings.Default.ShowsMillisec = newSettings.ShowsMillisec;
+        Properties.Settings.Default.ShowsRecordId = newSettings.ShowsRecordId;
         Properties.Settings.Default.Save();
 
         // Reflect new settings to the UI.
         ShowsMillisec = newSettings.ShowsMillisec;
+        ShowsRecordId = newSettings.ShowsRecordId;
 
         // Replace non-file logs with the new ones.
         readyToRefresh = false; // Avoid Refresh being called multiple times.

--- a/EventLook/ViewModel/SettingsData.cs
+++ b/EventLook/ViewModel/SettingsData.cs
@@ -10,4 +10,5 @@ public class SettingsData
     public List<Range> Ranges { get; set; }
     public Range SelectedRange { get; set; }
     public bool ShowsMillisec { get; set; }
+    public bool ShowsRecordId { get; set; }
 }

--- a/EventLook/ViewModel/SettingsViewModel.cs
+++ b/EventLook/ViewModel/SettingsViewModel.cs
@@ -26,6 +26,7 @@ public class SettingsViewModel : ObservableObject
         Ranges = new List<Model.Range>(originalSettings.Ranges);
         SelectedRange = Ranges.FirstOrDefault(r => r.Text == originalSettings.SelectedRange.Text);
         ShowsMillisec = originalSettings.ShowsMillisec;
+        ShowsRecordId = originalSettings.ShowsRecordId;
 
         AddCommand = new RelayCommand(AddLogSource);
         RemoveCommand = new RelayCommand(RemoveLogSource);
@@ -40,6 +41,7 @@ public class SettingsViewModel : ObservableObject
     private Model.Range selectedRange;
     public Model.Range SelectedRange { get => selectedRange; set => SetProperty(ref selectedRange, value); }
     public bool ShowsMillisec { get; set; }
+    public bool ShowsRecordId { get; set; }
 
     /// <summary>
     /// Returns the result of the settings dialog.
@@ -52,7 +54,8 @@ public class SettingsViewModel : ObservableObject
             LogSources = LogSources.ToList(),
             Ranges = Ranges.ToList(),
             SelectedRange = SelectedRange,
-            ShowsMillisec = ShowsMillisec
+            ShowsMillisec = ShowsMillisec,
+            ShowsRecordId = ShowsRecordId
         };
     }
 

--- a/EventLookPackage/Package.appxmanifest
+++ b/EventLookPackage/Package.appxmanifest
@@ -9,7 +9,7 @@
   <Identity
     Name="64247kmaki565.323654BB1C7D"
     Publisher="CN=B5234934-E68F-4911-8E10-60FECC338A02"
-    Version="1.5.1.0" />
+    Version="1.6.0.0" />
 
   <Properties>
     <DisplayName>EventLook</DisplayName>


### PR DESCRIPTION
- Reduce memory usage by disposing event records after reading
- Support move-around in Event Details
![image](https://github.com/kmaki565/EventLook/assets/16055659/327c2340-d5eb-478b-92d1-5406615e320d)

- Add setting to show Record ID
![image](https://github.com/kmaki565/EventLook/assets/16055659/7b0149ff-10aa-4ffc-aeb1-82bd564fe841)
- Show selected events count
![image](https://github.com/kmaki565/EventLook/assets/16055659/986d9953-3159-4691-b7d9-d613859f0b82)
