### PR TITLE
Update setup actions and reduce artifact size

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,10 +17,10 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-    - uses: actions/checkout@v2
-    - uses: nuget/setup-nuget@v1
+    - uses: actions/checkout@v4
+    - uses: nuget/setup-nuget@v2
     - run: nuget restore ${{ env.PROJECT_NAME }}.sln
-    - uses: microsoft/setup-msbuild@v1.0.2
+    - uses: microsoft/setup-msbuild@v2
     - run: msbuild ${{ env.PROJECT_NAME }}.sln '/p:Configuration=Release;Platform=x64;AppxBundle=Always;AppxBundlePlatforms=x64|x86|arm64;AppxPackageSigningEnabled=false'
     - name: Run unit test
       run: dotnet test Tests\Tests.csproj
@@ -29,8 +29,9 @@ jobs:
         Remove-Item -Recurse ${{ env.PROJECT_NAME }}\bin\ARM64
         Remove-Item -Recurse ${{ env.PROJECT_NAME }}\bin\x86
         Remove-Item -Recurse ${{ env.PROJECT_NAME }}\bin\x64\Release\net8.0-windows10.0.17763.0\win-x64
+        Remove-Item -Recurse ${{ env.PROJECT_NAME }}\bin\Debug
     # Save artifacts
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v4
       with:
         name: ${{ env.PROJECT_NAME }}-${{ github.sha }}
         path: ${{ env.PROJECT_NAME }}\bin


### PR DESCRIPTION
- Some setup actions used in the workflow have been deprecated, so updated those. 
- `Debug` folder had been included in the artifact since test was introduced in the steps, so removed the folder.