### PR TITLE
Add keyboard shortcut for up/down in detail window

### DIFF
--- a/EventLook/EventLook.csproj
+++ b/EventLook/EventLook.csproj
@@ -50,7 +50,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.2" />
-    <PackageReference Include="Extended.Wpf.Toolkit" Version="4.6.0" />
+    <PackageReference Include="Extended.Wpf.Toolkit" Version="4.6.1" />
     <PackageReference Include="Microsoft.DotNet.UpgradeAssistant.Extensions.Default.Analyzers" Version="0.4.421302" PrivateAssets="all" />
   </ItemGroup>
   <ItemGroup>

--- a/EventLook/View/DetailWindow.xaml
+++ b/EventLook/View/DetailWindow.xaml
@@ -7,11 +7,15 @@
         mc:Ignorable="d"
         FocusManager.FocusedElement="{Binding ElementName=RichTextBoxXml}"
         Title="Event Details" Height="550" Width="900">
+    <Window.InputBindings>
+        <KeyBinding Key="P" Modifiers="Ctrl" Command="{Binding UpCommand}"/>
+        <KeyBinding Key="N" Modifiers="Ctrl" Command="{Binding DownCommand}"/>
+    </Window.InputBindings>
     <Grid>
         <DockPanel>
             <StackPanel DockPanel.Dock="Right" VerticalAlignment="Center" HorizontalAlignment="Center">
-                <Button Command="{Binding UpCommand}" FontFamily="Segoe UI Symbol" Content="&#xE110;" FontSize="15" Width="30" Height="30" Margin="10"/>
-                <Button Command="{Binding DownCommand}" FontFamily="Segoe UI Symbol" Content="&#xE1FD;" FontSize="15" Width="30" Height="30" Margin="10"/>
+                <Button Command="{Binding UpCommand}" FontFamily="Segoe UI Symbol" Content="&#xE110;" FontSize="15" Width="30" Height="30" Margin="10" ToolTip="Previous event (Ctrl+P)"/>
+                <Button Command="{Binding DownCommand}" FontFamily="Segoe UI Symbol" Content="&#xE1FD;" FontSize="15" Width="30" Height="30" Margin="10" ToolTip="Next event (Ctrl+N)"/>
             </StackPanel>
             <RichTextBox Name="RichTextBoxXml" FontSize="13"
              local:TextBoxBehavior.HighlightedXml="{Binding EventXml, Mode=OneWay}"


### PR DESCRIPTION
Now you can use Ctrl+N/P for the down/up buttons when you browse XML of the events.
![image](https://github.com/user-attachments/assets/eafa9949-9dcd-4312-8c4a-e17e7e697e38)

In addition, the WPF Toolkit nuget package was updated. 
