### PR TITLE
Improve performance of Auto Refresh and Select All checkbox

### DIFF
--- a/EventLook/Model/EventItem.cs
+++ b/EventLook/Model/EventItem.cs
@@ -1,5 +1,7 @@
-﻿using System;
+﻿using CommunityToolkit.Mvvm.ComponentModel;
+using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics.Eventing.Reader;
 using System.Linq;
 using System.Text;
@@ -12,7 +14,7 @@ namespace EventLook.Model;
 /// Represents a event to display. 
 /// Could not inherit EventLogRecord as it doesn't have a public constructor.
 /// </summary>
-public class EventItem : IDisposable
+public class EventItem : ObservableObject, IDisposable
 {
     public EventItem(LogSource logSource, EventRecord eventRecord)
     {
@@ -62,10 +64,12 @@ public class EventItem : IDisposable
     /// Indicates the time when the event was loaded by the app.
     /// </summary>
     public DateTime TimeLoaded { get; set; }
+
     /// <summary>
     /// Indicates if the event is newly loaded.
     /// </summary>
-    public bool IsNewLoaded { get; set; }
+    private bool _isNewLoaded;
+    public bool IsNewLoaded { get => _isNewLoaded; set => SetProperty(ref _isNewLoaded, value); }
 
     public void Dispose()
     {

--- a/EventLook/Model/FilterBase.cs
+++ b/EventLook/Model/FilterBase.cs
@@ -43,7 +43,7 @@ public abstract class FilterBase : Monitorable
     /// <summary>
     /// Applies filter when the user operates the filter UI.
     /// </summary>
-    public void Apply()
+    public virtual void Apply()
     {
         if (cvs != null)
         {

--- a/EventLook/Model/LevelFilter.cs
+++ b/EventLook/Model/LevelFilter.cs
@@ -56,6 +56,13 @@ public class LevelFilter : FilterBase
     {
         levelFilters.Clear();
     }
+    public override void Apply()
+    {
+        if (IsFilterSelectionsChanged())
+        {
+            base.Apply();
+        }
+    }
 
     protected override bool IsFilterMatched(EventItem evt)
     {
@@ -95,6 +102,22 @@ public class LevelFilter : FilterBase
                 filterItem.Selected = false;
         }
         return true;
+    }
+
+    private readonly List<LevelFilterItem> _prevFilters = new List<LevelFilterItem>();
+    private bool IsFilterSelectionsChanged()
+    {
+        bool changed = levelFilters.Count != _prevFilters.Count || levelFilters.Where((lf, i) => lf.Level != _prevFilters[i].Level || lf.Selected != _prevFilters[i].Selected).Any();
+
+        if (changed)
+        {
+            _prevFilters.Clear();
+            foreach (var lf in levelFilters)
+            {
+                _prevFilters.Add(new LevelFilterItem { Level = lf.Level, Selected = lf.Selected });
+            }
+        }
+        return changed;
     }
 }
 

--- a/EventLook/Model/SourceFilter.cs
+++ b/EventLook/Model/SourceFilter.cs
@@ -58,6 +58,16 @@ public class SourceFilter : FilterBase
     {
         sourceFilters.Clear();
     }
+    public override void Apply()
+    {
+        // When Select All is clicked, this will be called for the number of the checkboxes.
+        // As I observed, selections of all checkboxes are already set at the first call
+        // so we can ignore the rest of the calls.
+        if (IsFilterSelectionsChanged())
+        {
+            base.Apply();
+        }
+    }
 
     protected override bool IsFilterMatched(EventItem evt)
     {
@@ -99,6 +109,23 @@ public class SourceFilter : FilterBase
                 filterItem.Selected = false;
         }
         return true;
+    }
+
+    readonly List<SourceFilterItem> _prevFilters = new List<SourceFilterItem>();
+    private bool IsFilterSelectionsChanged()
+    {
+        bool changed = sourceFilters.Count != _prevFilters.Count || sourceFilters.Where((sf, i) => sf.Name != _prevFilters[i].Name || sf.Selected != _prevFilters[i].Selected).Any();
+
+        if (changed)
+        {
+            _prevFilters.Clear();
+            foreach (var sf in sourceFilters)
+            {
+                _prevFilters.Add(new SourceFilterItem { Name = sf.Name, Selected = sf.Selected });
+            }
+        }
+
+        return changed;
     }
 }
 

--- a/EventLook/ViewModel/MainViewModel.cs
+++ b/EventLook/ViewModel/MainViewModel.cs
@@ -537,7 +537,7 @@ public class MainViewModel : ObservableRecipient
         Events.TakeWhile(e => e.IsNewLoaded)
             .Where(e => all || DateTime.Now - e.TimeLoaded >= newLoadedTimeThreshold)
             .ToList().ForEach(e => e.IsNewLoaded = false);
-        CVS.View.Refresh();
+
         return Events.Any(e => e.IsNewLoaded);
     }
 

--- a/EventLook/ViewModel/MainViewModel.cs
+++ b/EventLook/ViewModel/MainViewModel.cs
@@ -277,15 +277,12 @@ public class MainViewModel : ObservableRecipient
     {
         filters.ForEach(f => f.Clear());
     }
-    private async void ApplySourceFilter()
+    private void ApplySourceFilter()
     {
-        // Delay is needed to ensure filter update in UI is propagated to the source.
-        await Task.Delay(10);
         sourceFilter.Apply();
     }
-    private async void ApplyLevelFilter()
+    private void ApplyLevelFilter()
     {
-        await Task.Delay(10);
         levelFilter.Apply();
     }
     private void OpenDetails()


### PR DESCRIPTION
Apparently, calling `CVS.View.Refresh()` too frequently causes UI hang up sometimes. These two commits both aim to reduce the refresh calls. 

In `ApplySourceFilter()` and `ApplyLevelFilter()`, there were intentional delays but it somehow works without the delays now, so I removed these.