### PR TITLE
Auto save opened log source

### DIFF
--- a/EventLook/EventLook.csproj
+++ b/EventLook/EventLook.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <AssemblyTitle>A fast &amp; handy Event Viewer</AssemblyTitle>
-    <AssemblyVersion>1.6.1.0</AssemblyVersion>
+    <AssemblyVersion>1.6.2.0</AssemblyVersion>
     <Description>$(AssemblyTitle)</Description>
     <Copyright>Copyright (C) K. Maki</Copyright>
     <Product>EventLook</Product>

--- a/EventLook/ViewModel/MainViewModel.cs
+++ b/EventLook/ViewModel/MainViewModel.cs
@@ -593,7 +593,12 @@ public class MainViewModel : ObservableRecipient
         bool? ret = LogPickerWindowService.ShowDialog(openLogVm);
         if (ret == true && !string.IsNullOrEmpty(openLogVm.SelectedChannel?.Path))
         {
-            SelectedLogSource = logSourceMgr.AddLogSource(openLogVm.SelectedChannel.Path, PathType.LogName);
+            // If the chosen source is already in the list, just select it.
+            SelectedLogSource = LogSources.FirstOrDefault(x => x.Path == openLogVm.SelectedChannel.Path) ??
+                logSourceMgr.AddLogSource(openLogVm.SelectedChannel.Path, PathType.LogName, addToBottom: true);
+
+            Properties.Settings.Default.StartupLogNames = LogSources.Where(x => x.PathType == PathType.LogName).Select(x => x.Path).ToList();
+            Properties.Settings.Default.Save();
         }
     }
     /// <summary>

--- a/EventLookPackage/Package.appxmanifest
+++ b/EventLookPackage/Package.appxmanifest
@@ -9,7 +9,7 @@
   <Identity
     Name="64247kmaki565.323654BB1C7D"
     Publisher="CN=B5234934-E68F-4911-8E10-60FECC338A02"
-    Version="1.6.1.0" />
+    Version="1.6.2.0" />
 
   <Properties>
     <DisplayName>EventLook</DisplayName>


### PR DESCRIPTION
Event Logs (in local computer) accessed from the File menu or Ctrl+L can now be quickly accessed from the drop-down list after the next application launch. 
