### PR TITLE
Improved EVT support

### DIFF
--- a/EventLook/Model/EventItem.cs
+++ b/EventLook/Model/EventItem.cs
@@ -3,9 +3,11 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics.Eventing.Reader;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace EventLook.Model;
@@ -25,10 +27,11 @@ public class EventItem : ObservableObject, IDisposable
         {
             Message = eventRecord.FormatDescription();
 
-            // Formatting event message failed. Try to display information in EventData.
+            // Formatting event message failed, most likely because EventID was 0 or unknown.
+            // Display information in EventData instead.
             if (Message == null) 
             {
-                var sb = new StringBuilder("(EventLook - dump of EventData)\r\n");
+                var sb = new StringBuilder("EventData:\r\n");
                 for (int i = 0; i < eventRecord.Properties.Count; i++)
                 {
                     if (i > 0) sb.Append("\r\n");

--- a/EventLook/Model/EventItem.cs
+++ b/EventLook/Model/EventItem.cs
@@ -1,14 +1,8 @@
 ﻿using CommunityToolkit.Mvvm.ComponentModel;
 using System;
-using System.Collections.Generic;
-using System.ComponentModel;
 using System.Diagnostics.Eventing.Reader;
-using System.Globalization;
-using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace EventLook.Model;
 

--- a/EventLook/View/MainWindow.xaml
+++ b/EventLook/View/MainWindow.xaml
@@ -64,7 +64,7 @@
         <Menu DockPanel.Dock="Top" Background="White">
             <MenuItem Header="_File">
                 <MenuItem Header="Open Event _Log on local computer" InputGestureText="Ctrl+L" Command="{Binding OpenLogPickerCommand}"/>
-                <MenuItem Header="_Open .evtx File" InputGestureText="Ctrl+O" Command="{Binding OpenFileCommand}"/>
+                <MenuItem Header="_Open Event Log File" InputGestureText="Ctrl+O" Command="{Binding OpenFileCommand}"/>
                 <MenuItem Header="Export to C_SV file" InputGestureText="Ctrl+S" Command="{Binding ExportToCsvCommand}"/>
                 <Separator />
                 <MenuItem Header="Launch Windows _Event Viewer" Command="{Binding LaunchEventViewerCommand}"/>

--- a/EventLook/View/MainWindow.xaml.cs
+++ b/EventLook/View/MainWindow.xaml.cs
@@ -62,8 +62,8 @@ public partial class MainWindow : Window
             var fileName = args[1];
             if (File.Exists(fileName))
             {
-                var extension = System.IO.Path.GetExtension(fileName);
-                if (extension == ".evtx")
+                var extension = System.IO.Path.GetExtension(fileName)?.ToLowerInvariant();
+                if (extension == ".evtx" || extension == ".evt")
                 {
                     WeakReferenceMessenger.Default.Send(new FileToBeProcessedMessageToken() { FilePath = fileName });
                 }

--- a/EventLook/ViewModel/MainViewModel.cs
+++ b/EventLook/ViewModel/MainViewModel.cs
@@ -574,10 +574,14 @@ public class MainViewModel : ObservableRecipient
 
     private void OpenFile()
     {
+        //The Windows XML EventLog (EVTX) format is currently used by Microsoft Windows to store system log information.
+        //
+        //The Windows Event Log (EVT) format was deprecated in Windows Vista in favor of EVTX.
+        //It is not officially supported anymore, but System.Diagnostics.Eventing seems to work perfectly fine with it.
         OpenFileDialog openFileDialog = new()
         {
-            Filter = "Event Log files (*.evtx)|*.evtx",
-            Title = "Open .evtx file"
+            Filter = "Windows Event Log (*.evtx;*.evt)|*.evtx;*.evt",
+            Title = "Open Event Log File"
         };
         if (openFileDialog.ShowDialog() == true)
         {


### PR DESCRIPTION
Improved support for legacy EVT file format.
It was deprecated in Windows Vista in favor of EVTX.
It is not officially supported anymore, but System.Diagnostics.Eventing seems to work perfectly fine with it.
