### PR TITLE
Fix for #83

### DIFF
--- a/EventLook/ViewModel/MainViewModel.cs
+++ b/EventLook/ViewModel/MainViewModel.cs
@@ -407,9 +407,9 @@ public class MainViewModel : ObservableRecipient
     private async Task LoadEvents()
     {
         Cancel();
-
+        
         // When appending events, request events logged after the current newest event's time, from older to newer.
-        await Update(DataService.ReadEvents(SelectedLogSource, 
+        await Update(DataService.ReadEvents(SelectedLogSource, SelectedRange,
             IsAppend ? Events.First().TimeOfEvent : FromDateTime,
             ToDateTime, 
             readFromNew: !IsAppend,


### PR DESCRIPTION
Since the user only can set custom time down to the minute we need to query events from the start of the selected time minute and the end of the selected time minute.