### PR TITLE
Fix: Custom range may not fetch events consistently with UI

### DIFF
--- a/EventLook/ViewModel/MainViewModel.cs
+++ b/EventLook/ViewModel/MainViewModel.cs
@@ -387,9 +387,12 @@ public class MainViewModel : ObservableRecipient
     private void UpdateDateTimeInUi()
     {
         if (SelectedRange.IsCustom)
-            return;
-
-        if (SelectedRange.DaysFromNow == 0) // All time
+        {
+            // Cut off seconds from the time pickers since we only display up to minutes.
+            FromDateTime = new DateTime(FromDateTime.Year, FromDateTime.Month, FromDateTime.Day, FromDateTime.Hour, FromDateTime.Minute, 0);
+            ToDateTime = new DateTime(ToDateTime.Year, ToDateTime.Month, ToDateTime.Day, ToDateTime.Hour, ToDateTime.Minute, 0);
+        }
+        else if (SelectedRange.DaysFromNow == 0) // All time
         {
             FromDateTime = new DateTime(1970, 1, 1, 0, 0, 0);
             ToDateTime = new DateTime(2030, 12, 31, 0, 0, 0);


### PR DESCRIPTION
When Custom range is selected in the UI, `FromDateTime` and `ToDateTime` inherit the time information of the previously selected time (such as 4/18/2025 23:29:**43.111**). This can cause some events (such as at 4/18/2025 23:29:**12**) slipped out. 

To workaround, we could display second in the date time picker, but it's still confusing as we don't show millisecond information anyway. Rather, I chose to round down the date time objects to minute-base to match them to UI when custom range is selected.

Fixes #83