### PR TITLE
feat: Use system theme

### DIFF
--- a/AboutBoxWpf/AboutBoxWpf.csproj
+++ b/AboutBoxWpf/AboutBoxWpf.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0-windows10.0.17763.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.17763.0</TargetFramework>
     <Nullable>enable</Nullable>
     <UseWPF>true</UseWPF>
     <Platforms>AnyCPU;x64;x86;ARM64</Platforms>

--- a/EventLook/App.xaml
+++ b/EventLook/App.xaml
@@ -1,3 +1,4 @@
+<!-- ReSharper disable once ObsoleteElementError -->
 <Application x:Class="EventLook.App"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" 
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" 
@@ -5,24 +6,14 @@
              StartupUri="View/MainWindow.xaml" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              d1p1:Ignorable="d" 
-             xmlns:d1p1="http://schemas.openxmlformats.org/markup-compatibility/2006">
+             xmlns:d1p1="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             ThemeMode="System">
     <Application.Resources>
-        <FontFamily x:Key="WingDings3">./Font/WINGDNG3.TTF#Wingdings 3</FontFamily>
-        <Style TargetType="Button">
-            <Setter Property="Width" Value="60" />
-            <Setter Property="Height" Value="22" />
-            <Setter Property="Margin" Value="5,0,0,0" />
-        </Style>
-        <Style TargetType="DataGrid">
-            <Setter Property="BorderBrush" Value="LightSteelBlue"/>
-            <Setter Property="HorizontalGridLinesBrush" Value="LightSteelBlue"/>
-            <Setter Property="VerticalGridLinesBrush" Value="LightSteelBlue"/>
-            <Style.Resources>
-                <SolidColorBrush x:Key="{x:Static SystemColors.HighlightBrushKey}" Color="LightSkyBlue"/>
-                <SolidColorBrush x:Key="{x:Static SystemColors.HighlightTextBrushKey }" Color="Black"/>
-                <SolidColorBrush x:Key="{x:Static SystemColors.InactiveSelectionHighlightBrushKey}" Color="LightSteelBlue"/>
-                <SolidColorBrush x:Key="{x:Static SystemColors.InactiveSelectionHighlightTextBrushKey }" Color="Black"/>
-            </Style.Resources>
-        </Style>
+        <ResourceDictionary>
+            <FontFamily x:Key="WingDings3">./Font/WINGDNG3.TTF#Wingdings 3</FontFamily>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="pack://application:,,,/PresentationFramework.Fluent;component/Themes/Fluent.xaml" />
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
     </Application.Resources>
 </Application>

--- a/EventLook/EventLook.csproj
+++ b/EventLook/EventLook.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0-windows10.0.17763.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.17763.0</TargetFramework>
     <OutputType>WinExe</OutputType>
     <UseWPF>true</UseWPF>
     <ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
@@ -50,7 +50,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
-    <PackageReference Include="Extended.Wpf.Toolkit" Version="4.7.25104.5739" />
+    <PackageReference Include="Extended.Wpf.Toolkit" Version="5.0.0" />
     <PackageReference Include="Microsoft.DotNet.UpgradeAssistant.Extensions.Default.Analyzers" Version="0.4.421302" PrivateAssets="all" />
   </ItemGroup>
   <ItemGroup>

--- a/EventLook/Extensions/DependencyObjectExtensions.cs
+++ b/EventLook/Extensions/DependencyObjectExtensions.cs
@@ -1,0 +1,29 @@
+﻿using System.Windows;
+using System.Windows.Media;
+
+namespace EventLook.Extensions;
+
+internal static class DependencyObjectExtensions
+{
+    extension(DependencyObject tree)
+    {
+        // https://learn.microsoft.com/en-us/answers/questions/1806319/how-to-remove-the-clear-button-at-the-end-of-the-t
+        public DependencyObject FindChildElementByName(string sName)
+        {
+            for (var i = 0; i < VisualTreeHelper.GetChildrenCount(tree); i++)
+            {
+                var child = VisualTreeHelper.GetChild(tree, i);
+
+                // ReSharper disable once ConditionIsAlwaysTrueOrFalse
+                if (child != null && (child as FrameworkElement)?.Name == sName)
+                    return child;
+
+                var childInSubtree = FindChildElementByName(child, sName);
+                if (childInSubtree != null)
+                    return childInSubtree;
+            }
+
+            return null;
+        }
+    }
+}

--- a/EventLook/Extensions/TextBoxExtensions.cs
+++ b/EventLook/Extensions/TextBoxExtensions.cs
@@ -1,0 +1,24 @@
+﻿using System.Windows;
+using System.Windows.Controls;
+
+namespace EventLook.Extensions;
+
+internal static class TextBoxExtensions
+{
+    extension(TextBox textBox)
+    {
+        // https://learn.microsoft.com/en-us/answers/questions/1806319/how-to-remove-the-clear-button-at-the-end-of-the-t
+        public void DeleteFluentClearButton()
+        {
+            var childButton = textBox.FindChildElementByName("DeleteButton");
+            var parentGrid = (childButton as Control)?.Parent;
+            if (parentGrid != null)
+            {
+                if (childButton is UIElement childButtonElement)
+                {
+                    (parentGrid as Grid)?.Children.Remove(childButtonElement);
+                }
+            }
+        }
+    }
+}

--- a/EventLook/View/DateTimePickerCustom.xaml
+++ b/EventLook/View/DateTimePickerCustom.xaml
@@ -1,0 +1,50 @@
+﻿<UserControl x:Class="EventLook.View.DateTimePickerCustom"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             Height="Auto" Width="Auto"
+             Loaded="DateTimePickerCustom_Loaded">
+    <Grid>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="Auto" />
+        </Grid.ColumnDefinitions>
+
+        <DatePicker x:Name="PartDatePicker"
+                    SelectedDate="{Binding SelectedDate, RelativeSource={RelativeSource AncestorType=UserControl}, Mode=TwoWay, Converter={x:Null}}"
+                    VerticalAlignment="Center"
+                    Width="120">
+            <DatePicker.Style>
+                <Style TargetType="DatePicker" BasedOn="{StaticResource {x:Type DatePicker}}">
+                    <Setter Property="IsEnabled" Value="True"/>
+                    <Style.Triggers>
+                        <DataTrigger Binding="{Binding IsReadOnly, RelativeSource={RelativeSource AncestorType=UserControl}}" Value="True">
+                            <Setter Property="IsEnabled" Value="False"/>
+                        </DataTrigger>
+                    </Style.Triggers>
+                </Style>
+            </DatePicker.Style>
+        </DatePicker>
+
+        <TextBox Grid.Column="1" x:Name="PartTimeText"
+                 Width="60" Margin="6,0,0,0" VerticalContentAlignment="Center"
+                 Text="{Binding SelectedTimeString, RelativeSource={RelativeSource AncestorType=UserControl}, Mode=TwoWay}"
+                 ToolTip="Enter time as HH:mm"
+                 Loaded="PartTimeText_OnLoaded">
+            <TextBox.Style>
+                <Style TargetType="TextBox" BasedOn="{StaticResource {x:Type TextBox}}">
+                    <Setter Property="IsEnabled" Value="True"/>
+                    <Style.Triggers>
+                        <DataTrigger Binding="{Binding IsReadOnly, RelativeSource={RelativeSource AncestorType=UserControl}}" Value="True">
+                            <Setter Property="IsEnabled" Value="False"/>
+                        </DataTrigger>
+                    </Style.Triggers>
+                </Style>
+            </TextBox.Style>
+            <TextBox.InputBindings>
+                <KeyBinding Key="Enter"
+                            Command="{Binding MoveFocusCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"/>
+            </TextBox.InputBindings>
+        </TextBox>
+    </Grid>
+</UserControl>
+

--- a/EventLook/View/DateTimePickerCustom.xaml.cs
+++ b/EventLook/View/DateTimePickerCustom.xaml.cs
@@ -1,0 +1,147 @@
+﻿using System;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using CommunityToolkit.Mvvm.Input;
+using EventLook.Extensions;
+
+namespace EventLook.View;
+
+public sealed partial class DateTimePickerCustom
+{
+    private bool isUpdating;
+
+    public DateTimePickerCustom()
+    {
+        InitializeComponent();
+        MoveFocusCommand = new RelayCommand(() => PartTimeText.MoveFocus(new TraversalRequest(FocusNavigationDirection.Next)));
+    }
+
+    public IRelayCommand MoveFocusCommand { get; }
+
+    #region Value dependency property
+
+    public static readonly DependencyProperty ValueProperty =
+        DependencyProperty.Register(
+            nameof(Value),
+            typeof(DateTime),
+            typeof(DateTimePickerCustom),
+            new FrameworkPropertyMetadata(DateTime.Now, FrameworkPropertyMetadataOptions.BindsTwoWayByDefault, OnValueChanged));
+
+    public DateTime Value
+    {
+        get => (DateTime)GetValue(ValueProperty);
+        set => SetValue(ValueProperty, value);
+    }
+
+    private static void OnValueChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        var ctrl = (DateTimePickerCustom)d;
+        ctrl.UpdatePartsFromValue();
+    }
+
+    private void UpdatePartsFromValue()
+    {
+        if (isUpdating) return;
+        isUpdating = true;
+
+        SelectedDate = Value;
+        SelectedTimeString = TimeOnly.FromTimeSpan(Value.TimeOfDay).ToString(TimeFormat);
+
+        isUpdating = false;
+    }
+
+    #endregion Value dependency property
+
+    #region IsReadonly dependency property
+
+    public static readonly DependencyProperty IsReadOnlyProperty =
+        DependencyProperty.Register(nameof(IsReadOnly), typeof(bool), typeof(DateTimePickerCustom), new PropertyMetadata(false));
+
+    public bool IsReadOnly
+    {
+        get => (bool)GetValue(IsReadOnlyProperty);
+        set => SetValue(IsReadOnlyProperty, value);
+    }
+
+    #endregion IsReadonly dependency property
+
+    #region SelectedDate dependency property
+
+    public static readonly DependencyProperty SelectedDateProperty =
+        DependencyProperty.Register(
+            nameof(SelectedDate),
+            typeof(DateTime),
+            typeof(DateTimePickerCustom),
+            new FrameworkPropertyMetadata(DateTime.Now.Date, FrameworkPropertyMetadataOptions.BindsTwoWayByDefault, OnSelectedDateChanged));
+
+    public DateTime SelectedDate
+    {
+        get => (DateTime)GetValue(SelectedDateProperty);
+        set => SetValue(SelectedDateProperty, value);
+    }
+
+    private static void OnSelectedDateChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        var ctrl = (DateTimePickerCustom)d;
+
+        if (ctrl.isUpdating) return;
+        ctrl.isUpdating = true;
+
+        ctrl.Value = (DateTime)e.NewValue + ctrl.Value.TimeOfDay;
+
+        ctrl.isUpdating = false;
+    }
+
+    #endregion SelectedDate dependency property
+
+    #region SelectedTimeString dependency property
+
+    private const string TimeFormat = "HH:mm";
+
+    public static readonly DependencyProperty SelectedTimeStringProperty =
+        DependencyProperty.Register(
+            nameof(SelectedTimeString),
+            typeof(string),
+            typeof(DateTimePickerCustom),
+            new FrameworkPropertyMetadata(TimeOnly.MinValue.ToString(TimeFormat), FrameworkPropertyMetadataOptions.BindsTwoWayByDefault, OnSelectedTimeStringChanged));
+
+    public string SelectedTimeString
+    {
+        get => (string)GetValue(SelectedTimeStringProperty);
+        set => SetValue(SelectedTimeStringProperty, value);
+    }
+
+    private static void OnSelectedTimeStringChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        var ctrl = (DateTimePickerCustom)d;
+
+        if (ctrl.isUpdating) return;
+        ctrl.isUpdating = true;
+
+        // Allow HH:mm or HHmm format.
+        if (TimeOnly.TryParse((string)e.NewValue, out var time)
+            || (e.NewValue is string { Length: 4 } str
+                && TimeOnly.TryParse(str[..2] + ":" + str[2..], out time)))
+        {
+            // Ensure normalized time
+            ctrl.SelectedTimeString = time.ToString(TimeFormat);
+
+            ctrl.Value = ctrl.Value.Date + time.ToTimeSpan();
+        }
+
+        ctrl.isUpdating = false;
+    }
+
+    #endregion
+
+    private void DateTimePickerCustom_Loaded(object sender, RoutedEventArgs e)
+    {
+        UpdatePartsFromValue();
+    }
+
+    private void PartTimeText_OnLoaded(object sender, RoutedEventArgs e)
+    {
+        ((TextBox)sender).DeleteFluentClearButton();
+    }
+}

--- a/EventLook/View/DetailWindow.xaml
+++ b/EventLook/View/DetailWindow.xaml
@@ -8,14 +8,14 @@
         FocusManager.FocusedElement="{Binding ElementName=RichTextBoxXml}"
         Title="Event Details" Height="550" Width="900">
     <Window.InputBindings>
-        <KeyBinding Key="P" Modifiers="Ctrl" Command="{Binding UpCommand}"/>
-        <KeyBinding Key="N" Modifiers="Ctrl" Command="{Binding DownCommand}"/>
+        <KeyBinding Key="P" Modifiers="Control" Command="{Binding UpCommand}"/>
+        <KeyBinding Key="N" Modifiers="Control" Command="{Binding DownCommand}"/>
     </Window.InputBindings>
     <Grid>
         <DockPanel>
             <StackPanel DockPanel.Dock="Right" VerticalAlignment="Center" HorizontalAlignment="Center">
-                <Button Command="{Binding UpCommand}" FontFamily="Segoe UI Symbol" Content="&#xE110;" FontSize="15" Width="30" Height="30" Margin="10" ToolTip="Previous event (Ctrl+P)"/>
-                <Button Command="{Binding DownCommand}" FontFamily="Segoe UI Symbol" Content="&#xE1FD;" FontSize="15" Width="30" Height="30" Margin="10" ToolTip="Next event (Ctrl+N)"/>
+                <Button Command="{Binding UpCommand}" FontFamily="Segoe UI Symbol" Content="&#xE110;" FontSize="15" Width="30" Height="30" Margin="10" Padding="0" ToolTip="Previous event (Ctrl+P)"/>
+                <Button Command="{Binding DownCommand}" FontFamily="Segoe UI Symbol" Content="&#xE1FD;" FontSize="15" Width="30" Height="30" Margin="10" Padding="0" ToolTip="Next event (Ctrl+N)"/>
             </StackPanel>
             <RichTextBox Name="RichTextBoxXml" FontSize="13"
              local:TextBoxBehavior.HighlightedXml="{Binding EventXml, Mode=OneWay}"

--- a/EventLook/View/LogPickerWindow.xaml
+++ b/EventLook/View/LogPickerWindow.xaml
@@ -24,7 +24,7 @@
             </DockPanel>
             <CheckBox Margin="8" IsChecked="{Binding HidesEmptyLogs}">
                 <CheckBox.Style>
-                    <Style TargetType="CheckBox">
+                    <Style TargetType="CheckBox" BasedOn="{StaticResource {x:Type CheckBox}}">
                         <Style.Triggers>
                             <DataTrigger Binding="{Binding IsRunAsAdmin}" Value="False">
                                 <Setter Property="Content" Value="Hide empty logs (try run as admin to view logs with blank record count)"/>
@@ -43,12 +43,12 @@
                       IsReadOnly="True"
                       PreviewKeyDown="dataGrid1_PreviewKeyDown">
             <DataGrid.Resources>
-                <Style TargetType="DataGridRow">
+                <Style TargetType="DataGridRow" BasedOn="{StaticResource {x:Type DataGridRow}}">
                     <EventSetter Event="MouseDoubleClick" Handler="DataGridRow_MouseDoubleClick" />
                 </Style>
             </DataGrid.Resources>
             <DataGrid.CellStyle>
-                <Style TargetType="DataGridCell">
+                <Style TargetType="DataGridCell" BasedOn="{StaticResource {x:Type DataGridCell}}">
                     <Setter Property="BorderThickness" Value="0"/>
                     <Setter Property="FocusVisualStyle" Value="{x:Null}"/>
                 </Style>

--- a/EventLook/View/MainWindow.xaml
+++ b/EventLook/View/MainWindow.xaml
@@ -8,6 +8,7 @@
         xmlns:v="clr-namespace:EventLook.View"
         xmlns:viewmodel="clr-namespace:EventLook.ViewModel"
         xmlns:properties="clr-namespace:EventLook.Properties"
+        xmlns:local="clr-namespace:EventLook.View"
         d:DataContext="{d:DesignInstance Type=viewmodel:MainViewModel}"
         mc:Ignorable="d"
         ResizeMode="CanResizeWithGrip"
@@ -19,7 +20,7 @@
         WindowStartupLocation="CenterScreen"
         Closing="Window_Closing">
     <Window.Style>
-        <Style TargetType="Window">
+        <Style TargetType="Window" BasedOn="{StaticResource {x:Type Window}}">
             <Style.Triggers>
                 <DataTrigger Binding="{Binding IsRunAsAdmin}" Value="False">
                     <Setter Property="Title" Value="{Binding SelectedLogSource.Path, StringFormat={}{0} - EventLook}"/>
@@ -61,13 +62,13 @@
     <Window.InputBindings>
         <KeyBinding Key="F5" Command="{Binding RefreshCommand}"/>
         <KeyBinding Key="F5" Modifiers="Shift" Command="{Binding CancelCommand}"/>
-        <KeyBinding Key="L" Modifiers="Ctrl" Command="{Binding OpenLogPickerCommand}"/>
-        <KeyBinding Key="O" Modifiers="Ctrl" Command="{Binding OpenFileCommand}"/>
-        <KeyBinding Key="S" Modifiers="Ctrl" Command="{Binding ExportToCsvCommand}"/>
+        <KeyBinding Key="L" Modifiers="Control" Command="{Binding OpenLogPickerCommand}"/>
+        <KeyBinding Key="O" Modifiers="Control" Command="{Binding OpenFileCommand}"/>
+        <KeyBinding Key="S" Modifiers="Control" Command="{Binding ExportToCsvCommand}"/>
     </Window.InputBindings>
     
     <DockPanel>
-        <Menu DockPanel.Dock="Top" Background="White">
+        <Menu DockPanel.Dock="Top">
             <MenuItem Header="_File">
                 <MenuItem Header="Open Event _Log on local computer" InputGestureText="Ctrl+L" Command="{Binding OpenLogPickerCommand}"/>
                 <MenuItem Header="_Open .evtx File" InputGestureText="Ctrl+O" Command="{Binding OpenFileCommand}"/>
@@ -90,7 +91,7 @@
                 <MenuItem Header="_About EventLook" Click="MenuItem_About_Click"/>
             </MenuItem>
         </Menu>
-        <StatusBar DockPanel.Dock="Bottom" Background="WhiteSmoke">
+        <StatusBar DockPanel.Dock="Bottom" Padding="0">
             <StatusBarItem>
                 <StackPanel Orientation="Horizontal">
                     <TextBlock>
@@ -125,8 +126,8 @@
 
         <Grid>
             <Grid.RowDefinitions>
-                <RowDefinition Height="35"/>
-                <RowDefinition Height="{Binding ElementName=Ex1, Path=IsExpanded, Converter={StaticResource ExpandedToGridLengthConverter}, ConverterParameter=25}" />
+                <RowDefinition Height="40"/>
+                <RowDefinition Height="{Binding ElementName=Ex1, Path=IsExpanded, Converter={StaticResource ExpandedToGridLengthConverter}, ConverterParameter=50}" />
                 <RowDefinition/>
             </Grid.RowDefinitions>
 
@@ -134,30 +135,26 @@
                 <ComboBox  
                   x:Name="ComboBox_Source" ItemsSource="{Binding LogSources}" SelectedItem="{Binding SelectedLogSource}"
                   DisplayMemberPath="DisplayName" SelectedValuePath="Path" 
-                  HorizontalAlignment="Left" Margin="10,0,0,0" MinWidth="250" />
+                  HorizontalAlignment="Left" Margin="10,0,0,0" MinWidth="200" />
                 <ComboBox  
                       ItemsSource="{Binding Ranges}" SelectedItem="{Binding SelectedRange}"
                       DisplayMemberPath="Text" SelectedValuePath="Text"
                       HorizontalAlignment="Left" Margin="10,0,0,0" MinWidth="100" />
                 <TextBlock Text="From:" Margin="10,0,0,0" VerticalAlignment="Center" HorizontalAlignment="Right"/>
-                <xctk:DateTimePicker Margin="8,0,0,0" MinWidth="160" 
-                                 AutoCloseCalendar="True" 
+                <local:DateTimePickerCustom Margin="8,0,0,0"
                                  IsReadOnly="{Binding SelectedRange.IsCustom, Converter={StaticResource InverseBooleanConverter}}"
-                                 Value="{Binding FromDateTime, Mode=TwoWay, UpdateSourceTrigger=LostFocus}" 
-                                 Format="Custom" FormatString="yyyy-MM-dd HH:mm (z)"/>
+                                 Value="{Binding FromDateTime, Mode=TwoWay}" />
                 <TextBlock Text="To:" Margin="8,0,0,0" VerticalAlignment="Center" HorizontalAlignment="Right"/>
-                <xctk:DateTimePicker Margin="8,0,0,0" MinWidth="160"
-                                 AutoCloseCalendar="True"
+                <local:DateTimePickerCustom Margin="8,0,0,0"
                                  IsReadOnly="{Binding SelectedRange.IsCustom, Converter={StaticResource InverseBooleanConverter}}"
-                                 Value="{Binding ToDateTime, Mode=TwoWay, UpdateSourceTrigger=LostFocus}" 
-                                 Format="Custom" FormatString="yyyy-MM-dd HH:mm (z)"/>
+                                 Value="{Binding ToDateTime, Mode=TwoWay}" />
                 <ComboBox
                     ItemsSource="{Binding TimeZones}" SelectedItem="{Binding SelectedTimeZone}"
                     DisplayMemberPath="DisplayName"
-                    Margin="10,0,0,0" Width="93"/>
-                <Button x:Name="refreshButton" Margin="15,0,0,0" Width="25" Height="25">
+                    Margin="10,0,0,0" Width="125"/>
+                <Button x:Name="refreshButton" Margin="15,0,0,0" Padding="0" Width="30" Height="30">
                     <Button.Style>
-                        <Style TargetType="Button">
+                        <Style TargetType="Button" BasedOn="{StaticResource {x:Type Button}}">
                             <Style.Triggers>
                                 <DataTrigger Binding="{Binding IsUpdating}" Value="False">
                                     <Setter Property="Command" Value="{Binding RefreshCommand, Mode=OneWay}"/>
@@ -200,7 +197,7 @@
                     <TextBox x:Name="textBoxMsgFilter" Text="{Binding MsgFilter.MessageFilterText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, Delay=300}"
                              v:TextBoxBehavior.EscapeClearsText="True"
                              MinWidth="200" VerticalContentAlignment="Center" />
-                    <Button Content="Reset filters" Height="25" Width="70" Margin="15,0,0,0" Command="{Binding ResetFiltersCommand, Mode=OneWay}"/>
+                    <Button Content="Reset filters" Margin="15,0,0,0" Command="{Binding ResetFiltersCommand, Mode=OneWay}"/>
                 </StackPanel>
             </Expander>
 
@@ -239,16 +236,25 @@
                 </DataGrid.Resources>
                 <DataGrid.CellStyle>
                     <Style TargetType="DataGridCell">
-                        <Setter Property="BorderThickness" Value="0"/>
-                        <Setter Property="FocusVisualStyle" Value="{x:Null}"/>
+                        <Style.Triggers>
+                            <Trigger Property="IsSelected" Value="True">
+                                <Setter Property="Background" Value="{DynamicResource AccentFillColorTertiaryBrush}"/>
+                                <Setter Property="BorderThickness" Value="0"/>
+                                <Setter Property="FocusVisualStyle" Value="{x:Null}"/>
+                            </Trigger>
+                        </Style.Triggers>
                     </Style>
                 </DataGrid.CellStyle>
                 <DataGrid.RowStyle>
-                    <Style TargetType="DataGridRow">
+                    <Style TargetType="DataGridRow" BasedOn="{StaticResource {x:Type DataGridRow}}">
                         <Setter Property="ContextMenu" Value="{StaticResource dataGridContextMenu}" />
+                        <Setter Property="Height" Value="20" />
                         <Style.Triggers>
                             <DataTrigger Binding="{Binding IsNewLoaded}" Value="True">
-                                <Setter Property="Background" Value="Yellow"/>
+                                <Setter Property="Background" Value="{DynamicResource AccentFillColorDefaultBrush}"/>
+                            </DataTrigger>
+                            <DataTrigger Binding="{Binding IsNewLoaded}" Value="False">
+                                <Setter Property="Background" Value="{x:Null}"/>
                             </DataTrigger>
                         </Style.Triggers>
                     </Style>
@@ -275,7 +281,7 @@
                     </DataGridTextColumn>
                     <DataGridTextColumn Header="Provider" Binding="{Binding Record.ProviderName}" Width="200">
                         <DataGridTextColumn.ElementStyle>
-                            <Style TargetType="TextBlock">
+                            <Style TargetType="TextBlock" BasedOn="{StaticResource {x:Type TextBlock}}">
                                 <Style.Triggers>
                                     <DataTrigger Binding="{Binding IsChecked, Source={x:Reference CheckTruncate}}" Value="False">
                                         <Setter Property="TextWrapping" Value="Wrap" />
@@ -302,14 +308,14 @@
                     <DataGridTextColumn Header="Event ID" Binding="{Binding Record.Id}"/>
                     <DataGridTextColumn Header="Message" Binding="{Binding Message}" Width="*" Visibility="{Binding IsChecked, Source={x:Reference CheckTruncate}, Converter={StaticResource InverseBooleanToVisibilityConverter}}">
                         <DataGridTextColumn.ElementStyle>
-                            <Style TargetType="TextBlock">
+                            <Style TargetType="TextBlock" BasedOn="{StaticResource {x:Type TextBlock}}">
                                 <Setter Property="TextWrapping" Value="Wrap" />
                             </Style>
                         </DataGridTextColumn.ElementStyle>
                     </DataGridTextColumn>
                     <DataGridTextColumn Header="Message" Binding="{Binding MessageOneLine}" Width="*" Visibility="{Binding IsChecked, Source={x:Reference CheckTruncate}, Converter={StaticResource BooleanToVisibilityConverter}}">
                         <DataGridTextColumn.ElementStyle>
-                            <Style TargetType="TextBlock">
+                            <Style TargetType="TextBlock" BasedOn="{StaticResource {x:Type TextBlock}}">
                                 <Setter Property="TextTrimming" Value="CharacterEllipsis" />
                             </Style>
                         </DataGridTextColumn.ElementStyle>

--- a/EventLook/View/SettingsWindow.xaml
+++ b/EventLook/View/SettingsWindow.xaml
@@ -7,7 +7,7 @@
         xmlns:viewmodel="clr-namespace:EventLook.ViewModel"
         d:DataContext="{d:DesignInstance Type=viewmodel:SettingsViewModel}"
         mc:Ignorable="d"
-        Title="Settings" Height="360" Width="450" Background="WhiteSmoke">
+        Title="Settings" Height="375" Width="485">
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition />
@@ -24,11 +24,11 @@
                              ItemsSource="{Binding LogSources}" SelectedItem="{Binding SelectedLogSource}"
                              DisplayMemberPath="Path" SelectedValuePath="Path" />
                     <StackPanel Grid.Column="1" Orientation="Vertical" HorizontalAlignment="Center" Margin="10,10,12,10">
-                        <Button Content="Add" Command="{Binding AddCommand}" Width="90" Margin="0,5"/>
-                        <Button Content="Remove" Command="{Binding RemoveCommand}" Width="90" Margin="0,5"/>
-                        <Button Content="Move Up" Command="{Binding UpCommand}" Width="90" Margin="0,5"/>
-                        <Button Content="Move Down" Command="{Binding DownCommand}" Width="90" Margin="0,5"/>
-                        <Button Content="Restore Default" Command="{Binding RestoreDefaultCommand}" Width="90" Margin="0,25"/>
+                        <Button Content="Add" Command="{Binding AddCommand}" Width="120" Margin="0,5"/>
+                        <Button Content="Remove" Command="{Binding RemoveCommand}" Width="120" Margin="0,5"/>
+                        <Button Content="Move Up" Command="{Binding UpCommand}" Width="120" Margin="0,5"/>
+                        <Button Content="Move Down" Command="{Binding DownCommand}" Width="120" Margin="0,5"/>
+                        <Button Content="Restore Default" Command="{Binding RestoreDefaultCommand}" Width="120" Margin="0,25"/>
                     </StackPanel>
                 </Grid>
             </TabItem>

--- a/EventLook/View/TextBoxBehavior.cs
+++ b/EventLook/View/TextBoxBehavior.cs
@@ -134,7 +134,8 @@ public class TextBoxBehavior
         var declaration = xmlDoc.Declaration;
         if (declaration != null)
         {
-            paragraph.Inlines.Add(new Run($"<?xml version=\"{declaration.Version}\" encoding=\"{declaration.Encoding}\"?>") { Foreground = Brushes.SlateGray });
+            var brush = GetBrush("AccentTextFillColorDisabledBrush");
+            paragraph.Inlines.Add(new Run($"<?xml version=\"{declaration.Version}\" encoding=\"{declaration.Encoding}\"?>") { Foreground = brush });
             paragraph.Inlines.Add(new LineBreak());
         }
 
@@ -153,30 +154,36 @@ public class TextBoxBehavior
     /// </summary>
     private static void AddElementToParagraph(Paragraph paragraph, XElement element, int indentLevel)
     {
+        var tagBrush = GetBrush("AccentTextFillColorPrimaryBrush");
+        var attrBrush = GetBrush("TextFillColorSecondaryBrush");
+        var valueBrush = GetBrush("AccentTextFillColorTertiaryBrush");
+        var punctuationBrush = GetBrush("TextFillColorTertiaryBrush");
+        var textBrush = GetBrush("TextFillColorPrimaryBrush");
+
         var indent = new string(' ', indentLevel * 2);
         paragraph.Inlines.Add(new Run(indent));
 
         var prefix = element.GetPrefixOfNamespace(element.Name.Namespace);
         var elementName = !string.IsNullOrEmpty(prefix) ? $"{prefix}:{element.Name.LocalName}" : element.Name.LocalName;
-        paragraph.Inlines.Add(new Run($"<{elementName}") { Foreground = Brushes.MediumBlue });
+        paragraph.Inlines.Add(new Run($"<{elementName}") { Foreground = tagBrush });
 
         // Add attributes
         foreach (var attribute in element.Attributes())
         {
-            paragraph.Inlines.Add(new Run($" {attribute.Name}") { Foreground = Brushes.Firebrick });
-            paragraph.Inlines.Add(new Run("=") { Foreground = Brushes.SlateGray });
-            paragraph.Inlines.Add(new Run($"\"{attribute.Value}\"") { Foreground = Brushes.ForestGreen });
+            paragraph.Inlines.Add(new Run($" {attribute.Name}") { Foreground = attrBrush });
+            paragraph.Inlines.Add(new Run("=") { Foreground = punctuationBrush });
+            paragraph.Inlines.Add(new Run($"\"{attribute.Value}\"") { Foreground = valueBrush });
         }
 
         if (element.IsEmpty || string.IsNullOrWhiteSpace(element.Value))
         {
             // Self-closing tag
-            paragraph.Inlines.Add(new Run(" />") { Foreground = Brushes.MediumBlue });
+            paragraph.Inlines.Add(new Run(" />") { Foreground = tagBrush });
             paragraph.Inlines.Add(new LineBreak());
         }
         else
         {
-            paragraph.Inlines.Add(new Run(">") { Foreground = Brushes.MediumBlue });
+            paragraph.Inlines.Add(new Run(">") { Foreground = tagBrush });
 
             if (!string.IsNullOrWhiteSpace(element.Value) && !element.HasElements)
             {
@@ -184,15 +191,15 @@ public class TextBoxBehavior
                 if (element.Value.Contains("\n"))
                 {
                     paragraph.Inlines.Add(new LineBreak());
-                    paragraph.Inlines.Add(new Run($"{new string(' ', (indentLevel + 1) * 2)}{element.Value}") { Foreground = Brushes.Black });
+                    paragraph.Inlines.Add(new Run($"{new string(' ', (indentLevel + 1) * 2)}{element.Value}") { Foreground = textBrush });
                     paragraph.Inlines.Add(new LineBreak());
-                    paragraph.Inlines.Add(new Run($"{indent}</{elementName}>") { Foreground = Brushes.MediumBlue });
+                    paragraph.Inlines.Add(new Run($"{indent}</{elementName}>") { Foreground = tagBrush });
                     paragraph.Inlines.Add(new LineBreak());
                 }
                 else
                 {
-                    paragraph.Inlines.Add(new Run(element.Value) { Foreground = Brushes.Black });
-                    paragraph.Inlines.Add(new Run($"</{elementName}>") { Foreground = Brushes.MediumBlue });
+                    paragraph.Inlines.Add(new Run(element.Value) { Foreground = textBrush });
+                    paragraph.Inlines.Add(new Run($"</{elementName}>") { Foreground = tagBrush });
                     paragraph.Inlines.Add(new LineBreak());
                 }
             }
@@ -204,7 +211,7 @@ public class TextBoxBehavior
                 {
                     AddElementToParagraph(paragraph, childElement, indentLevel + 1);
                 }
-                paragraph.Inlines.Add(new Run($"{indent}</{elementName}>") { Foreground = Brushes.MediumBlue });
+                paragraph.Inlines.Add(new Run($"{indent}</{elementName}>") { Foreground = tagBrush });
                 paragraph.Inlines.Add(new LineBreak());
             }
         }
@@ -231,6 +238,8 @@ public class TextBoxBehavior
         return stringBuilder.ToString();
     }
 
+    private static Brush GetBrush(string key) =>
+        (Brush)Application.Current.Resources[key] ?? Brushes.Black;
 
     #endregion Attached Property HighlightedXml
 }

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	<TargetFramework>net8.0-windows10.0.17763.0</TargetFramework>
+	<TargetFramework>net10.0-windows10.0.17763.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 


### PR DESCRIPTION
Motivation:
Allow users (myself) not to lose eyesight when opening a light app in a dark themed OS.

Changes:
1. Update to .NET 10 ([.NET 9](https://learn.microsoft.com/en-us/dotnet/desktop/wpf/whats-new/net90#thememode) could have worked, but didn't test with it) to allow using native windows theming capabilities + auto switch between light/dark
2. Kill all hardcoded brushes
3. Implement custom datetime picker to avoid theme issues with xceed control - dates and times become unreadable there. Couldn't find a workaround.
3.1. CheckComboBox is still used - despite not respecting dark theme it's still readable.
4. Adjust control sizes while still preserving compact look & feel of the main datagrid

Important:
Only tested on Win 11 25H2 (build 26200.7171). I don't know what OS versions you try to support.

Screenshots dark:
<img width="2437" height="1336" alt="grafik" src="https://github.com/user-attachments/assets/5a395163-dd4d-47c0-b167-c3f75776d67e" />
<img width="1871" height="1146" alt="grafik" src="https://github.com/user-attachments/assets/519aaebf-ef51-41d1-9e1f-3574dea1efdb" />
<img width="2437" height="1336" alt="grafik" src="https://github.com/user-attachments/assets/c8b0c152-5c98-4917-bd6d-e5cc73ae8f89" />

Screenshots light:
<img width="2437" height="1336" alt="grafik" src="https://github.com/user-attachments/assets/5de00cd2-3f73-4f3f-9e1a-a9981880b50b" />
<img width="1871" height="1146" alt="grafik" src="https://github.com/user-attachments/assets/91ff74fc-75d9-4ccc-9c3f-deeb1f3680c9" />
<img width="999" height="778" alt="grafik" src="https://github.com/user-attachments/assets/30a50c10-3926-4c61-ac73-c843f8c49f2b" />

Space for improvements (either find a way to override xceed styles or make a custom control):
<img width="1411" height="771" alt="grafik" src="https://github.com/user-attachments/assets/c001a8c9-3d69-4f4e-8d17-9dd0d2f8c38e" />
